### PR TITLE
Patch targetcreated events (fixes #6)

### DIFF
--- a/packages/puppeteer-extra-plugin-anonymize-ua/test/popup.js
+++ b/packages/puppeteer-extra-plugin-anonymize-ua/test/popup.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const { test } = require('ava')
+
+const PUPPETEER_ARGS = ['--no-sandbox', '--disable-setuid-sandbox']
+
+const waitEvent = function (emitter, eventName) {
+  return new Promise(resolve => emitter.once(eventName, resolve))
+}
+
+test.beforeEach(t => {
+  // Make sure we work with pristine modules
+  delete require.cache[require.resolve('puppeteer-extra')]
+  delete require.cache[require.resolve('puppeteer-extra-plugin-anonymize-ua')]
+})
+
+test('known issue: will not remove headless from implicitly created popup pages', async (t) => {
+  const puppeteer = require('puppeteer-extra')
+  puppeteer.use(require('puppeteer-extra-plugin-anonymize-ua')())
+  const browser = await puppeteer.launch({ args: PUPPETEER_ARGS })
+
+  const pages = await Promise.all(
+    [...Array(10)].map(slot => browser.newPage())
+  )
+  for (const page of pages) {
+    // Works
+    const ua = await page.evaluate(() => window.navigator.userAgent)
+    t.true(!ua.includes('HeadlessChrome'))
+
+    // Works
+    await page.goto('about:blank')
+    const ua2 = await page.evaluate(() => window.navigator.userAgent)
+    t.true(!ua2.includes('HeadlessChrome'))
+
+    // Does NOT work:
+    // https://github.com/GoogleChrome/puppeteer/issues/2669
+    page.evaluate(url => window.open(url), 'about:blank')
+    const popupTarget = await waitEvent(browser, 'targetcreated')
+    const popupPage = await popupTarget.page()
+    const ua3 = await popupPage.evaluate(() => window.navigator.userAgent)
+    // Test against the problem until it's fixed
+    t.true(ua3.includes('HeadlessChrome')) // should be: !ua3.includes('HeadlessChrome')
+
+    // Works: The bug only affects newly created popups, subsequent page navigations are fine.
+    await popupPage.goto('about:blank')
+    const ua4 = await page.evaluate(() => window.navigator.userAgent)
+    t.true(!ua4.includes('HeadlessChrome'))
+  }
+
+  await browser.close()
+  t.true(true)
+})

--- a/packages/puppeteer-extra-plugin-anonymize-ua/test/stresstest.js
+++ b/packages/puppeteer-extra-plugin-anonymize-ua/test/stresstest.js
@@ -1,0 +1,89 @@
+'use strict'
+
+const { test } = require('ava')
+
+const PUPPETEER_ARGS = ['--no-sandbox', '--disable-setuid-sandbox']
+
+test.beforeEach(t => {
+  // Make sure we work with pristine modules
+  delete require.cache[require.resolve('puppeteer-extra')]
+  delete require.cache[require.resolve('puppeteer-extra-plugin-anonymize-ua')]
+})
+
+test('will remove headless from the user-agent on multiple browsers', async (t) => {
+  const puppeteer = require('puppeteer-extra')
+  puppeteer.use(require('puppeteer-extra-plugin-anonymize-ua')())
+  const browser = await puppeteer.launch({ args: PUPPETEER_ARGS })
+
+  const browsers = await Promise.all(
+    [...Array(5)].map(slot => puppeteer.launch({ args: PUPPETEER_ARGS }))
+  )
+  for (const browser of browsers) {
+    const page = await browser.newPage()
+    const ua = await page.evaluate(() => window.navigator.userAgent)
+    t.true(ua.includes('Windows NT 10.0'))
+    t.true(!ua.includes('HeadlessChrome'))
+  }
+
+  await browser.close()
+  t.true(true)
+})
+
+test('will remove headless from the user-agent on many pages', async (t) => {
+  const puppeteer = require('puppeteer-extra')
+  puppeteer.use(require('puppeteer-extra-plugin-anonymize-ua')())
+  const browser = await puppeteer.launch({ args: PUPPETEER_ARGS })
+
+  const pages = await Promise.all(
+    [...Array(30)].map(slot => browser.newPage())
+  )
+  for (const page of pages) {
+    const ua = await page.evaluate(() => window.navigator.userAgent)
+    t.true(ua.includes('Windows NT 10.0'))
+    t.true(!ua.includes('HeadlessChrome'))
+  }
+
+  await browser.close()
+  t.true(true)
+})
+
+test('will remove headless from the user-agent on many incognito pages', async (t) => {
+  const puppeteer = require('puppeteer-extra')
+  puppeteer.use(require('puppeteer-extra-plugin-anonymize-ua')())
+  const browser = await puppeteer.launch({ args: PUPPETEER_ARGS })
+
+  // Requires puppeteer@next currrently
+  if (browser.createIncognitoBrowserContext) {
+    const contexts = await Promise.all(
+      [...Array(30)].map(slot => browser.createIncognitoBrowserContext())
+    )
+    for (const context of contexts) {
+      const page = await context.newPage()
+      const ua = await page.evaluate(() => window.navigator.userAgent)
+      t.true(ua.includes('Windows NT 10.0'))
+      t.true(!ua.includes('HeadlessChrome'))
+    }
+  }
+
+  await browser.close()
+  t.true(true)
+})
+
+test('will remove headless from the user-agent on many pages in parallel', async (t) => {
+  const puppeteer = require('puppeteer-extra')
+  puppeteer.use(require('puppeteer-extra-plugin-anonymize-ua')())
+  const browser = await puppeteer.launch({ args: PUPPETEER_ARGS })
+
+  const testCase = async () => {
+    const page = await browser.newPage()
+    const ua = await page.evaluate(() => window.navigator.userAgent)
+    t.true(ua.includes('Windows NT 10.0'))
+    t.true(!ua.includes('HeadlessChrome'))
+  }
+  await Promise.all(
+    [...Array(30)].map(slot => testCase())
+  )
+
+  await browser.close()
+  t.true(true)
+})

--- a/packages/puppeteer-extra-plugin/index.js
+++ b/packages/puppeteer-extra-plugin/index.js
@@ -37,7 +37,7 @@ const merge = require('merge-deep')
  * const puppeteer = require('puppeteer-extra')
  * puppeteer.use(require('./hello-world-plugin')())
  *
- * (async () => {
+ * ;(async () => {
  *   const browser = await puppeteer.launch({headless: false})
  *   const page = await browser.newPage()
  *   await page.goto('http://example.com', {waitUntil: 'domcontentloaded'})

--- a/packages/puppeteer-extra-plugin/readme.md
+++ b/packages/puppeteer-extra-plugin/readme.md
@@ -73,7 +73,7 @@ module.exports = function (pluginConfig) { return new Plugin(pluginConfig) }
 const puppeteer = require('puppeteer-extra')
 puppeteer.use(require('./hello-world-plugin')())
 
-(async () => {
+;(async () => {
   const browser = await puppeteer.launch({headless: false})
   const page = await browser.newPage()
   await page.goto('http://example.com', {waitUntil: 'domcontentloaded'})


### PR DESCRIPTION
Note: This patch only fixes explicitly created pages, implicitly created ones
(e.g. through `window.open`) are still subject to this issue. I didn't find a
reliable mitigation for implicitly created pages yet.