### PR TITLE
Simplify puppeteer import, fixes #17

### DIFF
--- a/packages/puppeteer-extra/index.js
+++ b/packages/puppeteer-extra/index.js
@@ -1,9 +1,9 @@
 'use strict'
 
-let Puppeteer, PuppeteerBrowserFetcher
+let Puppeteer
 try {
-  Puppeteer = require('puppeteer/lib/Puppeteer')
-  PuppeteerBrowserFetcher = require('puppeteer/lib/BrowserFetcher')
+  // https://github.com/GoogleChrome/puppeteer/pull/3208
+  Puppeteer = require('puppeteer')
 } catch (err) {
   console.warn(`
     Puppeteer is missing. :-)
@@ -386,7 +386,7 @@ class PuppeteerExtra {
    * @return {PuppeteerBrowserFetcher}
    */
   createBrowserFetcher (options) {
-    return new PuppeteerBrowserFetcher(options)
+    return Puppeteer.createBrowserFetcher(options)
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6640,6 +6640,19 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
+puppeteer@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.npmjs.org/puppeteer/-/puppeteer-1.8.0.tgz#9e8bbd2f5448cc19cac220efc0512837104877ad"
+  dependencies:
+    debug "^3.1.0"
+    extract-zip "^1.6.6"
+    https-proxy-agent "^2.2.1"
+    mime "^2.0.3"
+    progress "^2.0.0"
+    proxy-from-env "^1.0.0"
+    rimraf "^2.6.1"
+    ws "^5.1.1"
+
 puppeteer@next:
   version "1.7.0-next.1534528770278"
   resolved "https://registry.npmjs.org/puppeteer/-/puppeteer-1.7.0-next.1534528770278.tgz#3bd20e7e496cad825cccf11000f6166f1813b09b"


### PR DESCRIPTION
After refactoring starting in `puppeteer@1.8.0` the call signature changed in `lib/Puppeteer.js`:
https://github.com/GoogleChrome/puppeteer/pull/3208

This PR simplifies the puppeteer import and fixes this issue (and makes it less likely to break again in the future).
