### PR TITLE
Fix getParameter fallback usage

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/webgl.vendor/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/webgl.vendor/index.js
@@ -19,7 +19,7 @@ class Plugin extends PuppeteerExtraPlugin {
     await page.evaluateOnNewDocument(() => {
       try {
         /* global WebGLRenderingContext */
-        const getParameter = WebGLRenderingContext.getParameter
+        WebGLRenderingContext.prototype.oldGetParameter = WebGLRenderingContext.prototype.getParameter;
         WebGLRenderingContext.prototype.getParameter = function (parameter) {
           // UNMASKED_VENDOR_WEBGL
           if (parameter === 37445) {
@@ -29,7 +29,7 @@ class Plugin extends PuppeteerExtraPlugin {
           if (parameter === 37446) {
             return 'Intel Iris OpenGL Engine'
           }
-          return getParameter(parameter)
+          return this.oldGetParameter(parameter);
         }
       } catch (err) {}
     })


### PR DESCRIPTION
I don't think the reference to the original getParameter function works correctly. I've found a specific case where the website I'm trying to hit uses WebGL as part of its browser fingerprinting. The JavaScript tries to get several parameters (that do not have hardcoded values here) and Chrome spits out `TypeError: getParameter is not a function`. Adding the old version of the function to the prototype and calling it that way seems to work.

You can replicate the existing bug by loading this plugin, navigating to any web page and running the following in the console:

```
const canvas = document.createElement('canvas');
const context = canvas.getContext('webgl');
context.getParameter(123);
```

My change allows this code to run correctly and return correct values for any Parameter that isn't over-written by the plugin.