### PR TITLE
Try to fallback to `puppeteer-core` if `puppeteer` is not available

### DIFF
--- a/packages/puppeteer-extra/index.js
+++ b/packages/puppeteer-extra/index.js
@@ -3,7 +3,11 @@
 let Puppeteer
 try {
   // https://github.com/GoogleChrome/puppeteer/pull/3208
-  Puppeteer = require('puppeteer')
+  try {
+    Puppeteer = require('puppeteer')
+  } catch (err) {
+    Puppeteer = require('puppeteer-core')
+  }
 } catch (err) {
   console.warn(`
     Puppeteer is missing. :-)


### PR DESCRIPTION
What it says on the label. Maybe not the flexible as it doesn’t make it easier to dropin forks &c., but it’s a quick solution that probably does what *most* people are looking for. Cf. https://github.com/berstend/puppeteer-extra/issues/27