### PR TITLE
Fix getParameter spoofing for WebGLRenderingContext

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/webgl.vendor/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/webgl.vendor/index.js
@@ -19,7 +19,7 @@ class Plugin extends PuppeteerExtraPlugin {
     await page.evaluateOnNewDocument(() => {
       try {
         /* global WebGLRenderingContext */
-        const getParameter = WebGLRenderingContext.getParameter
+        const getParameter = WebGLRenderingContext.prototype.getParameter
         WebGLRenderingContext.prototype.getParameter = function(parameter) {
           // UNMASKED_VENDOR_WEBGL
           if (parameter === 37445) {
@@ -29,7 +29,7 @@ class Plugin extends PuppeteerExtraPlugin {
           if (parameter === 37446) {
             return 'Intel Iris OpenGL Engine'
           }
-          return getParameter(parameter)
+          return getParameter.apply(this, [parameter])
         }
       } catch (err) {}
     })


### PR DESCRIPTION
Hey,

We've faced the issue mentioned here:
https://github.com/berstend/puppeteer-extra/issues/33#issuecomment-497033554

So, here is the fix.