### PR TITLE
feat(plugin-stealth): Add new user-agent-language-platform plugin

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-language-platform/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-language-platform/index.js
@@ -1,0 +1,68 @@
+'use strict'
+
+const { PuppeteerExtraPlugin } = require('puppeteer-extra-plugin')
+
+const userInfo = msg => {
+  console.log(`INFO: puppeteer-extra-plugin-stealth(user-agent-language-platform): ${msg}`)
+}
+
+/**
+ * By default puppeteer will have a fixed locale setting, represented in the `Accept-Language` header and in `navigator.languages`.
+ * In addition, the `navigator.platform` and `navigator.vendor` properties are always set to the host values, so for example platform `Linux` which makes detection very easy.
+ * 
+ * This plugin fixes these issues. Please know that you cannot use the regular ``page.setUserAgent()`` puppeteer call in your code,
+ * as it will reset the language and platform values you set with this plugin.
+ *
+ * @example
+ * const puppeteer = require("puppeteer-extra")
+ *
+ * const StealthPlugin = require("puppeteer-extra-plugin-stealth")
+ * const stealth = StealthPlugin()
+ * // Remove this specific stealth plugin from the default set
+ * stealth.enabledEvasions.delete("user-agent-language-platform")
+ * puppeteer.use(stealth)
+ *
+ * // Stealth plugins are just regular `puppeteer-extra` plugins and can be added as such
+ * const UserAgentLanguagePlatformPlugin = require("puppeteer-extra-plugin-stealth/evasions/user-agent-language-platform")
+ * const ualpp = UserAgentLanguagePlatformPlugin({ userAgent: "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)", locale: "de-DE,de;q=0.9", platform: "Win32", vendor: 'Google Inc.' }) // Custom UA, locale, platform and vendor
+ * puppeteer.use(ualpp)
+ *
+ * @param {Object} [opts] - Options
+ * @param {string} [opts.userAgent] - The user agent to use (default: browser.userAgent())
+ * @param {string} [opts.locale] - The locale to use in `Accept-Language` header and in `navigator.languages` (default: `en-US,en;q=0.9`)
+ * @param {string} [opts.platform] - The platform to use in `navigator.platform` (default: `Win32`)
+ * @param {string} [opts.vendor] - The vendor to use in `navigator.vendor` (default: `Google Inc.`)
+ *
+ */
+class Plugin extends PuppeteerExtraPlugin {
+  constructor(opts = {}) {
+    super(opts)
+  }
+
+  get name() {
+    return 'stealth/evasions/user-agent-language-platform'
+  }
+
+  get defaults() {
+    return { userAgent: null, acceptLanguage: 'en-US,en;q=0.9', platform: 'Win32', vendor: 'Google Inc.' }
+  }
+
+  async onPageCreated(page) {
+    this.debug('onPageCreated - Will set these user agent options', {
+      opts: this.opts
+    })
+    console.log("opts", this.opts)
+
+    page._client.send('Network.setUserAgentOverride', { userAgent: this.opts.userAgent || (await page.browser().userAgent()), acceptLanguage: this.opts.locale || 'en-US,en;q=0.9', platform: this.opts.platform || 'Win32' })    
+
+    await page.evaluateOnNewDocument((v) => {
+        // Overwrite the `vendor` property to use a custom getter.
+        Object.defineProperty(navigator, 'vendor', {
+            get: () => v
+        })
+    }, this.opts.vendor || 'Google Inc.')
+  } // onPageCreated
+}
+
+const defaultExport = opts => new Plugin(opts)
+module.exports = defaultExport

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-language-platform/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-language-platform/index.js
@@ -51,7 +51,6 @@ class Plugin extends PuppeteerExtraPlugin {
     this.debug('onPageCreated - Will set these user agent options', {
       opts: this.opts
     })
-    console.log("opts", this.opts)
 
     page._client.send('Network.setUserAgentOverride', { userAgent: this.opts.userAgent || (await page.browser().userAgent()), acceptLanguage: this.opts.locale || 'en-US,en;q=0.9', platform: this.opts.platform || 'Win32' })    
 

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-language-platform/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-language-platform/index.js
@@ -2,14 +2,10 @@
 
 const { PuppeteerExtraPlugin } = require('puppeteer-extra-plugin')
 
-const userInfo = msg => {
-  console.log(`INFO: puppeteer-extra-plugin-stealth(user-agent-language-platform): ${msg}`)
-}
-
 /**
  * By default puppeteer will have a fixed locale setting, represented in the `Accept-Language` header and in `navigator.languages`.
  * In addition, the `navigator.platform` and `navigator.vendor` properties are always set to the host values, so for example platform `Linux` which makes detection very easy.
- * 
+ *
  * This plugin fixes these issues. Please know that you cannot use the regular ``page.setUserAgent()`` puppeteer call in your code,
  * as it will reset the language and platform values you set with this plugin.
  *
@@ -44,7 +40,12 @@ class Plugin extends PuppeteerExtraPlugin {
   }
 
   get defaults() {
-    return { userAgent: null, acceptLanguage: 'en-US,en;q=0.9', platform: 'Win32', vendor: 'Google Inc.' }
+    return {
+      userAgent: null,
+      acceptLanguage: 'en-US,en;q=0.9',
+      platform: 'Win32',
+      vendor: 'Google Inc.'
+    }
   }
 
   async onPageCreated(page) {
@@ -52,13 +53,17 @@ class Plugin extends PuppeteerExtraPlugin {
       opts: this.opts
     })
 
-    page._client.send('Network.setUserAgentOverride', { userAgent: this.opts.userAgent || (await page.browser().userAgent()), acceptLanguage: this.opts.locale || 'en-US,en;q=0.9', platform: this.opts.platform || 'Win32' })    
+    page._client.send('Network.setUserAgentOverride', {
+      userAgent: this.opts.userAgent || (await page.browser().userAgent()),
+      acceptLanguage: this.opts.locale || 'en-US,en;q=0.9',
+      platform: this.opts.platform || 'Win32'
+    })
 
-    await page.evaluateOnNewDocument((v) => {
-        // Overwrite the `vendor` property to use a custom getter.
-        Object.defineProperty(navigator, 'vendor', {
-            get: () => v
-        })
+    await page.evaluateOnNewDocument(v => {
+      // Overwrite the `vendor` property to use a custom getter.
+      Object.defineProperty(navigator, 'vendor', {
+        get: () => v
+      })
     }, this.opts.vendor || 'Google Inc.')
   } // onPageCreated
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-language-platform/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-language-platform/index.js
@@ -4,7 +4,7 @@ const { PuppeteerExtraPlugin } = require('puppeteer-extra-plugin')
 
 /**
  * By default puppeteer will have a fixed locale setting, represented in the `Accept-Language` header and in `navigator.languages`.
- * In addition, the `navigator.platform` and `navigator.vendor` properties are always set to the host values, so for example platform `Linux` which makes detection very easy.
+ * In addition, the `navigator.platform` property is always set to the host value, so for example `Linux` which makes detection very easy.
  *
  * This plugin fixes these issues. Please know that you cannot use the regular ``page.setUserAgent()`` puppeteer call in your code,
  * as it will reset the language and platform values you set with this plugin.
@@ -20,14 +20,13 @@ const { PuppeteerExtraPlugin } = require('puppeteer-extra-plugin')
  *
  * // Stealth plugins are just regular `puppeteer-extra` plugins and can be added as such
  * const UserAgentLanguagePlatformPlugin = require("puppeteer-extra-plugin-stealth/evasions/user-agent-language-platform")
- * const ualpp = UserAgentLanguagePlatformPlugin({ userAgent: "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)", locale: "de-DE,de;q=0.9", platform: "Win32", vendor: 'Google Inc.' }) // Custom UA, locale, platform and vendor
+ * const ualpp = UserAgentLanguagePlatformPlugin({ userAgent: "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)", locale: "de-DE,de;q=0.9", platform: "Win32" }) // Custom UA, locale and platform
  * puppeteer.use(ualpp)
  *
  * @param {Object} [opts] - Options
  * @param {string} [opts.userAgent] - The user agent to use (default: browser.userAgent())
  * @param {string} [opts.locale] - The locale to use in `Accept-Language` header and in `navigator.languages` (default: `en-US,en;q=0.9`)
  * @param {string} [opts.platform] - The platform to use in `navigator.platform` (default: `Win32`)
- * @param {string} [opts.vendor] - The vendor to use in `navigator.vendor` (default: `Google Inc.`)
  *
  */
 class Plugin extends PuppeteerExtraPlugin {
@@ -43,8 +42,7 @@ class Plugin extends PuppeteerExtraPlugin {
     return {
       userAgent: null,
       acceptLanguage: 'en-US,en;q=0.9',
-      platform: 'Win32',
-      vendor: 'Google Inc.'
+      platform: 'Win32'
     }
   }
 
@@ -54,17 +52,15 @@ class Plugin extends PuppeteerExtraPlugin {
     })
 
     page._client.send('Network.setUserAgentOverride', {
-      userAgent: this.opts.userAgent || (await page.browser().userAgent()),
+      userAgent:
+        this.opts.userAgent ||
+        (await page.browser().userAgent()).replace(
+          'HeadlessChrome/',
+          'Chrome/'
+        ),
       acceptLanguage: this.opts.locale || 'en-US,en;q=0.9',
       platform: this.opts.platform || 'Win32'
     })
-
-    await page.evaluateOnNewDocument(v => {
-      // Overwrite the `vendor` property to use a custom getter.
-      Object.defineProperty(navigator, 'vendor', {
-        get: () => v
-      })
-    }, this.opts.vendor || 'Google Inc.')
   } // onPageCreated
 }
 

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-language-platform/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-language-platform/index.js
@@ -41,7 +41,7 @@ class Plugin extends PuppeteerExtraPlugin {
   get defaults() {
     return {
       userAgent: null,
-      acceptLanguage: 'en-US,en;q=0.9',
+      acceptLanguage: 'en-US,en',
       platform: 'Win32'
     }
   }
@@ -58,7 +58,7 @@ class Plugin extends PuppeteerExtraPlugin {
           'HeadlessChrome/',
           'Chrome/'
         ),
-      acceptLanguage: this.opts.locale || 'en-US,en;q=0.9',
+      acceptLanguage: this.opts.locale || 'en-US,en',
       platform: this.opts.platform || 'Win32'
     })
   } // onPageCreated

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-language-platform/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-language-platform/index.test.js
@@ -1,0 +1,138 @@
+const test = require('ava')
+
+const { vanillaPuppeteer, addExtra } = require('../../test/util')
+const Plugin = require('.')
+
+test('vanilla: Accept-Language header is missing', async t => {
+  const browser = await vanillaPuppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+  await page.goto('http://httpbin.org/headers')
+
+  const content = await page.content()
+  t.true(content.includes(`"User-Agent"`))
+  t.false(content.includes(`"Accept-Language"`))
+})
+
+test('vanilla: User-Agent header contains HeadlessChrome', async t => {
+  const browser = await vanillaPuppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+  await page.goto('http://httpbin.org/headers')
+
+  const content = await page.content()
+  t.true(content.includes(`"User-Agent"`))
+  t.true(content.includes(`HeadlessChrome`))
+})
+
+test('vanilla: navigator.languages is always en-US', async t => {
+  const browser = await vanillaPuppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+  const lang = await page.evaluate(() => navigator.languages)
+  t.true(lang.length === 1 && lang[0] === 'en-US')
+})
+
+test('vanilla: navigator.platform set to host platform', async t => {
+  const browser = await vanillaPuppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+
+  const platform = await page.evaluate(() => navigator.platform)
+  switch (process.platform) {
+    case 'linux':
+      t.true(platform === 'Linux')
+      break
+    case 'darwin':
+      t.true(platform === 'MacIntel')
+      break
+    case 'win32':
+      t.true(platform === 'Win32')
+      break
+    default:
+      t.true(platform === process.platform)
+  }
+})
+
+test('stealth: Accept-Language header with default locale', async t => {
+  const puppeteer = addExtra(vanillaPuppeteer).use(Plugin())
+  const browser = await puppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+  await page.goto('http://httpbin.org/headers')
+
+  const content = await page.content()
+  t.true(content.includes(`"User-Agent"`))
+  t.true(content.includes(`"Accept-Language": "en-US,en;q=0.9"`))
+})
+
+test('stealth: Accept-Language header with optional locale', async t => {
+  const puppeteer = addExtra(vanillaPuppeteer).use(
+    Plugin({ locale: 'de-DE,de' })
+  )
+  const browser = await puppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+  await page.goto('http://httpbin.org/headers')
+
+  const content = await page.content()
+  t.true(content.includes(`"User-Agent"`))
+  t.true(content.includes(`"Accept-Language": "de-DE,de;q=0.9"`))
+})
+
+test('stealth: User-Agent header does not contain HeadlessChrome', async t => {
+  const puppeteer = addExtra(vanillaPuppeteer).use(Plugin())
+  const browser = await puppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+  await page.goto('http://httpbin.org/headers')
+
+  const content = await page.content()
+  t.true(content.includes(`"User-Agent"`))
+  t.false(content.includes(`HeadlessChrome`))
+})
+
+test('stealth: User-Agent header with custom userAgent', async t => {
+  const puppeteer = addExtra(vanillaPuppeteer).use(
+    Plugin({ userAgent: 'MyFunkyUA/1.0' })
+  )
+  const browser = await puppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+  await page.goto('http://httpbin.org/headers')
+
+  const content = await page.content()
+  t.true(content.includes(`"User-Agent": "MyFunkyUA/1.0"`))
+})
+
+test('stealth: navigator.languages with default locale', async t => {
+  const puppeteer = addExtra(vanillaPuppeteer).use(Plugin())
+  const browser = await puppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+
+  const lang = await page.evaluate(() => navigator.languages)
+  t.true(lang.length === 2 && lang[0] === 'en-US' && lang[1] === 'en')
+})
+
+test('stealth: navigator.languages with custom locale', async t => {
+  const puppeteer = addExtra(vanillaPuppeteer).use(
+    Plugin({ locale: 'de-DE,de' })
+  )
+  const browser = await puppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+
+  const lang = await page.evaluate(() => navigator.languages)
+  t.true(lang.length === 2 && lang[0] === 'de-DE' && lang[1] === 'de')
+})
+
+test('stealth: navigator.platform with default platform', async t => {
+  const puppeteer = addExtra(vanillaPuppeteer).use(Plugin())
+  const browser = await puppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+
+  const platform = await page.evaluate(() => navigator.platform)
+  t.true(platform === 'Win32')
+})
+
+test('stealth: navigator.platform with custom platform', async t => {
+  const puppeteer = addExtra(vanillaPuppeteer).use(
+    Plugin({ platform: 'MyFunkyPlatform' })
+  )
+  const browser = await puppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+
+  const platform = await page.evaluate(() => navigator.platform)
+  t.true(platform === 'MyFunkyPlatform')
+})

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-language-platform/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-language-platform/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "main": "index.js"
+}


### PR DESCRIPTION
This plugin basically replaces the following evasions:
https://github.com/berstend/puppeteer-extra/tree/master/packages/puppeteer-extra-plugin-stealth/evasions/accept-language
https://github.com/berstend/puppeteer-extra/tree/master/packages/puppeteer-extra-plugin-stealth/evasions/navigator.languages
At the same time, it fixes https://github.com/berstend/puppeteer-extra/issues/91

Instead of changing request headers and the ``navigator.languages`` (``navigator.language`` was missing by the way) properties as in the evasions above, we use call ``setUserAgentOverride`` in the CDP Network domain directly which is a better way of achieving this.

In addition, this evasion allows setting the ``navigator.platform`` and ``navigator.vendor`` properties, which makes it a lot less easy to detect puppeteer.