### PR TITLE
Keep user options when defaults are not defined

### DIFF
--- a/packages/puppeteer-extra-plugin/src/index.test.ts
+++ b/packages/puppeteer-extra-plugin/src/index.test.ts
@@ -15,10 +15,10 @@ test('will throw without a name', async t => {
 test('should have the basic class members', async t => {
   const pluginName = 'hello-world'
   class Plugin extends PuppeteerExtraPlugin {
-    constructor (opts = {}) {
+    constructor(opts = {}) {
       super(opts)
     }
-    get name () {
+    get name() {
       return pluginName
     }
   }
@@ -38,10 +38,10 @@ test('should have the basic class members', async t => {
 test('should have the public class members', async t => {
   const pluginName = 'hello-world'
   class Plugin extends PuppeteerExtraPlugin {
-    constructor (opts = {}) {
+    constructor(opts = {}) {
       super(opts)
     }
-    get name () {
+    get name() {
       return pluginName
     }
   }
@@ -63,10 +63,10 @@ test('should have the public class members', async t => {
 test('should have the internal class members', async t => {
   const pluginName = 'hello-world'
   class Plugin extends PuppeteerExtraPlugin {
-    constructor (opts = {}) {
+    constructor(opts = {}) {
       super(opts)
     }
-    get name () {
+    get name() {
       return pluginName
     }
   }
@@ -86,13 +86,13 @@ test('should merge opts with defaults automatically', async t => {
   const userOpts = { foo2: 'bob', extra2: 666 }
 
   class Plugin extends PuppeteerExtraPlugin {
-    constructor (opts = {}) {
+    constructor(opts = {}) {
       super(opts)
     }
-    get name () {
+    get name() {
       return pluginName
     }
-    get defaults () {
+    get defaults() {
       return pluginDefaults
     }
   }
@@ -103,4 +103,21 @@ test('should merge opts with defaults automatically', async t => {
   t.is(instance.opts.foo2, userOpts.foo2)
   t.is(instance.opts.extra1, pluginDefaults.extra1)
   t.is(instance.opts.extra2, userOpts.extra2)
+})
+
+test('should have opts when defaults is not defined', async t => {
+  const pluginName = 'hello-world'
+  const userOpts = { foo2: 'bob', extra2: 666 }
+
+  class Plugin extends PuppeteerExtraPlugin {
+    constructor(opts = {}) {
+      super(opts)
+    }
+    get name() {
+      return pluginName
+    }
+  }
+  const instance = new Plugin(userOpts)
+
+  t.deepEqual(instance.opts, userOpts)
 })

--- a/packages/puppeteer-extra-plugin/src/index.ts
+++ b/packages/puppeteer-extra-plugin/src/index.ts
@@ -74,11 +74,7 @@ export abstract class PuppeteerExtraPlugin {
     this._debugBase = debug(`puppeteer-extra-plugin:base:${this.name}`)
     this._childClassMembers = []
 
-    this._opts = {}
-    // Deep merge opts with defaults, if available
-    if (Object.keys(this.defaults).length) {
-      this._opts = merge(this.defaults, opts || {})
-    }
+    this._opts = merge(this.defaults, opts || {})
 
     this._debugBase('Initialized.')
   }


### PR DESCRIPTION
Hello,

If the defaults are not defined (or defined as an empty object) in a plugin, user options are ignored.

I've fixed the issue (+ added test to confirm).

Thanks!