### PR TITLE
Fix for calling functions on proxy (navigator.webdriver evasion)

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.webdriver/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.webdriver/index.js
@@ -20,8 +20,12 @@ class Plugin extends PuppeteerExtraPlugin {
       Object.defineProperty(window, 'navigator', {
         value: new Proxy(navigator, {
           has: (target, key) => (key === 'webdriver' ? false : key in target),
-          get: (target, key, receiver) =>
-            key === 'webdriver' ? undefined : target[key]
+          get: (target, key) =>
+            key === 'webdriver'
+              ? undefined
+              : typeof target[key] === 'function'
+              ? target[key].bind(target)
+              : target[key]
         })
       })
     })


### PR DESCRIPTION
This fixes function calls on the navigator object, for example ``navigator.javaEnabled()`` which is called by Google Analytics.

Related Chromium bug: https://bugs.chromium.org/p/v8/issues/detail?id=5773