### PR TITLE
Remove puppeteer dependency

### DIFF
--- a/packages/puppeteer-extra-plugin-adblocker/package.json
+++ b/packages/puppeteer-extra-plugin-adblocker/package.json
@@ -50,7 +50,6 @@
     "@types/node-fetch": "^2.5.4",
     "@types/puppeteer": "^2.0.0",
     "ava": "^2.4.0",
-    "puppeteer": "2.0.0",
     "ts-node": "^8.5.4",
     "tslint": "^5.20.1",
     "tslint-config-prettier": "^1.18.0",


### PR DESCRIPTION
This plugin depends on puppeteer-extra and not puppeteer. A hardcoded version makes the yarn install puppeteer twice in the project in latest versions.