### PR TITLE
Fixing issue with the setMaxListeners

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/index.js
@@ -151,8 +151,10 @@ class StealthPlugin extends PuppeteerExtraPlugin {
   }
 
   async onBrowser(browser) {
-    // Increase event emitter listeners to prevent MaxListenersExceededWarning
-    browser.setMaxListeners(30)
+    if (browser && browser.setMaxListeners) {
+      // Increase event emitter listeners to prevent MaxListenersExceededWarning
+      browser.setMaxListeners(30)
+    }
   }
 }
 


### PR DESCRIPTION
### Problem:
New versions of puppeteer do not longer support the method setMaxListeners, and it makes puppeteer-extra-stealth not usable. 

### Solution 

This PR check if the method available before running it.


-----
Related Issue: https://github.com/berstend/puppeteer-extra/issues/228