### PR TITLE
Support script tag detection for different domains

### DIFF
--- a/packages/puppeteer-extra-plugin-recaptcha/src/index.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/index.ts
@@ -62,7 +62,7 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
     // As this might be called very early while recaptcha is still loading
     // we add some extra waiting logic for developer convenience.
     const hasRecaptchaScriptTag = await page.$(
-      `script[src^="https://www.google.com/recaptcha/api.js"]`
+      `script[src*="/recaptcha/api.js"]`
     )
     this.debug('hasRecaptchaScriptTag', !!hasRecaptchaScriptTag)
     if (hasRecaptchaScriptTag) {


### PR DESCRIPTION
Some sites use `https://www.recaptcha.net/recaptcha/api.js` instead of `https://www.google.com/recaptcha/api.js` (e.g. [Mintos](https://www.mintos.com/en/login)).