### PR TITLE
fix(plugin-stealth): Harden navigator.plugins evasion

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.js
@@ -156,7 +156,7 @@ class Plugin extends PuppeteerExtraPlugin {
         }
 
         const mimeTypeArray = generateMimeTypeArray()
-        Object.defineProperty(navigator, 'mimeTypes', {
+        Object.defineProperty(Object.getPrototypeOf(navigator), 'mimeTypes', {
           get: () => mimeTypeArray
         })
 
@@ -196,7 +196,7 @@ class Plugin extends PuppeteerExtraPlugin {
         }
 
         const pluginArray = generatePluginArray()
-        Object.defineProperty(navigator, 'plugins', {
+        Object.defineProperty(Object.getPrototypeOf(navigator), 'plugins', {
           get: () => pluginArray
         })
 

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.test.js
@@ -4,6 +4,8 @@ const {
   getVanillaFingerPrint,
   getStealthFingerPrint
 } = require('../../test/util')
+const { vanillaPuppeteer, addExtra } = require('../../test/util')
+
 const Plugin = require('.')
 
 test('vanilla: empty plugins, empty mimetypes', async t => {
@@ -12,8 +14,43 @@ test('vanilla: empty plugins, empty mimetypes', async t => {
   t.is(mimeTypes.length, 0)
 })
 
+test('vanilla: will not have modifications', async t => {
+  const browser = await vanillaPuppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+
+  const test1 = await page.evaluate(() => ({
+    mimeTypes: Object.getOwnPropertyDescriptor(navigator, 'mimeTypes'), // Must be undefined if native
+    plugins: Object.getOwnPropertyDescriptor(navigator, 'plugins') // Must be undefined if native
+  }))
+  t.is(test1.mimeTypes, undefined)
+  t.is(test1.plugins, undefined)
+
+  const test2 = await page.evaluate(
+    () => Object.getOwnPropertyNames(navigator) // Must be an empty array if native
+  )
+  t.deepEqual(test2, [])
+})
+
 test('stealth: has plugin, has mimetypes', async t => {
   const { plugins, mimeTypes } = await getStealthFingerPrint(Plugin)
   t.is(plugins.length, 3)
   t.is(mimeTypes.length, 4)
+})
+
+test('stealth: will not leak modifications', async t => {
+  const puppeteer = addExtra(vanillaPuppeteer).use(Plugin())
+  const browser = await puppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+
+  const test1 = await page.evaluate(() => ({
+    mimeTypes: Object.getOwnPropertyDescriptor(navigator, 'mimeTypes'), // Must be undefined if native
+    plugins: Object.getOwnPropertyDescriptor(navigator, 'plugins') // Must be undefined if native
+  }))
+  t.is(test1.mimeTypes, undefined)
+  t.is(test1.plugins, undefined)
+
+  const test2 = await page.evaluate(
+    () => Object.getOwnPropertyNames(navigator) // Must be an empty array if native
+  )
+  t.deepEqual(test2, [])
 })


### PR DESCRIPTION
Alright, this is the last one of those 😅 

With that our `navigator` props are peachy clean and this will return an empty array when using stealth:

```js
Object.getOwnPropertyNames(navigator)
// ==> []
```
