### PR TITLE
Empty launch options

### DIFF
--- a/packages/puppeteer-extra/src/index.ts
+++ b/packages/puppeteer-extra/src/index.ts
@@ -153,7 +153,7 @@ export class PuppeteerExtra implements VanillaPuppeteer {
   async launch(options?: Puppeteer.LaunchOptions): Promise<Puppeteer.Browser> {
     // Ensure there are certain properties (e.g. the `options.args` array)
     const defaultLaunchOptions = { args: [] }
-    options = merge(defaultLaunchOptions, options as any)
+    options = merge(defaultLaunchOptions, options || {} as any)
     this.resolvePluginDependencies()
     this.orderPlugins()
 


### PR DESCRIPTION
This pull request addresses an issue where calling `puppeteer.launch()` without passing any options would trigger an error.

Closes: #223 #195 

Signed-off-by: Bruno Gaspar <brunofgaspar1@gmail.com>