### PR TITLE
Add package: extract-stealth-evasions

### DIFF
--- a/packages/extract-stealth-evasions/.gitignore
+++ b/packages/extract-stealth-evasions/.gitignore
@@ -1,0 +1,1 @@
+stealth.min.js

--- a/packages/extract-stealth-evasions/index.js
+++ b/packages/extract-stealth-evasions/index.js
@@ -1,0 +1,70 @@
+const puppeteer = require('puppeteer-extra')
+const stealth = require('puppeteer-extra-plugin-stealth')();
+const { minify } = require("terser");
+const argv = require('yargs')
+  .usage('Usage: $0 [options]')
+  .alias('e', 'exclude')
+  .describe('e', 'Exclude evasion (repeat for multuple)')
+  .alias('i', 'include')
+  .describe('i', 'Include evasion (repeat for multuple)')
+  .alias('l', 'list')
+  .describe('l', 'List available evasions')
+  .help('h')
+  .alias('h', 'help')
+  .argv;
+const fs = require("fs");
+
+const file = 'stealth.min.js';
+
+if (argv.exclude) {
+  if (typeof argv.exclude === 'string') {
+    stealth.enabledEvasions.delete(argv.exclude)
+  } else {
+    argv.exclude.forEach(e => {
+      stealth.enabledEvasions.delete(e)
+    });
+  }
+} else if (argv.include) {
+  if (typeof argv.include === 'string') {
+    stealth.enabledEvasions = argv.include
+  } else {
+    stealth.enabledEvasions = [];
+    argv.include.forEach(e => {
+      stealth.enabledEvasions.push(e)
+    });
+  }
+} else if (argv.list) {
+  console.log('Available evasions:', stealth.availableEvasions);
+  process.exit(0);
+}
+
+let scripts = '';
+
+puppeteer
+  .use(stealth)
+  .launch({
+    headless: true,
+  })
+  .then(async browser => {
+    // Patch evaluateOnNewDocument()
+    const page = (await browser.pages()).find(Boolean);
+    page.__proto__.evaluateOnNewDocument = patchEval;
+    page.__proto__.evaluate = patchEval;
+
+    await (await browser.newPage()).goto('about:blank');
+    await browser.close();
+
+    fs.writeFile(file, (await minify(scripts, { toplevel: true })).code, (err) => {
+      if (err) throw err;
+      console.log(`File ${file} written!`)
+    });
+  });
+
+function patchEval(f, args) {
+  // Check if there are options supplied
+  if (typeof args != 'undefined') {
+    scripts += '(' + f.toString() + ')(' + JSON.stringify(args) + ');\n';
+  } else {
+    scripts += '(' + f.toString() + ')();\n';
+  }
+}

--- a/packages/extract-stealth-evasions/index.js
+++ b/packages/extract-stealth-evasions/index.js
@@ -26,7 +26,7 @@ if (argv.exclude) {
   }
 } else if (argv.include) {
   if (typeof argv.include === 'string') {
-    stealth.enabledEvasions = argv.include
+    stealth.enabledEvasions = [argv.include]
   } else {
     stealth.enabledEvasions = [];
     argv.include.forEach(e => {

--- a/packages/extract-stealth-evasions/index.js
+++ b/packages/extract-stealth-evasions/index.js
@@ -34,7 +34,7 @@ if (argv.exclude) {
     });
   }
 } else if (argv.list) {
-  console.log('Available evasions:', stealth.availableEvasions);
+  console.log('Available evasions:', [...stealth.availableEvasions].join(', '));
   process.exit(0);
 }
 
@@ -56,7 +56,8 @@ puppeteer
 
     fs.writeFile(file, (await minify(scripts, { toplevel: true })).code, (err) => {
       if (err) throw err;
-      console.log(`File ${file} written!`)
+      console.log(`File ${file} written!`);
+      console.log('Included evasions: ', [...stealth.enabledEvasions].join(', '));
     });
   });
 

--- a/packages/extract-stealth-evasions/package.json
+++ b/packages/extract-stealth-evasions/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "extract-stealth-evasions",
+  "version": "2.2.12",
+  "description": "Extract stealth evasions from puppeteer-extra-stealth",
+  "main": "index.js",
+  "repository": "berstend/puppeteer-extra",
+  "author": "berstend",
+  "license": "MIT",
+  "engines": {
+    "node": ">=8"
+  },
+  "keywords": [
+    "puppeteer",
+    "puppeteer-extra",
+    "puppeteer-extra-plugin",
+    "chrome",
+    "headless",
+    "pupeteer"
+  ],
+  "devDependencies": {
+    "puppeteer": "latest",
+    "puppeteer-extra": "latest",
+    "puppeteer-extra-plugin-stealth": "latest",
+    "terser": "^5.1.0",
+    "yargs": "^15.4.1"
+  }
+}

--- a/packages/extract-stealth-evasions/package.json
+++ b/packages/extract-stealth-evasions/package.json
@@ -18,9 +18,9 @@
     "pupeteer"
   ],
   "devDependencies": {
-    "puppeteer": "latest",
-    "puppeteer-extra": "latest",
-    "puppeteer-extra-plugin-stealth": "latest",
+    "puppeteer": "*",
+    "puppeteer-extra": "*",
+    "puppeteer-extra-plugin-stealth": "*",
     "terser": "^5.1.0",
     "yargs": "^15.4.1"
   }

--- a/packages/extract-stealth-evasions/readme.md
+++ b/packages/extract-stealth-evasions/readme.md
@@ -1,0 +1,24 @@
+# extract-stealth-evasions
+
+This script offers a quick way to extract the latest stealth evasions from [puppeteer-extra-stealth](https://github.com/berstend/puppeteer-extra/tree/master/packages/puppeteer-extra-plugin-stealth) to (minified) JavaScript. The resulting JS file can be used in pure [CDP](https://chromedevtools.github.io/devtools-protocol/tot/) implementations or to test the evasions in your devtools.
+
+#### How to use
+```bash
+yarn install
+node .
+```
+
+Use the resulting `stealth.min.js` file however you like.
+
+#### Options
+```bash
+$ node index -h
+Usage: index [options]
+
+Options:
+  --version      Show version number                                   [boolean]
+  -e, --exclude  Exclude evasion (repeat for multuple)
+  -i, --include  Include evasion (repeat for multuple)
+  -l, --list     List available evasions
+  -h, --help     Show help                                             [boolean]
+```


### PR DESCRIPTION
This is a simple script to extract the stealth evasions to a minified JS file that can be used in browsers/non-puppeteer environments.