### PR TITLE
feat(plugin-recaptcha): Improve invisible iframe support

### DIFF
--- a/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
@@ -29,7 +29,7 @@ export class RecaptchaContentScript {
     props.reduce((a, e) => ({ ...a, [e]: o[e] }), {})
 
   // make sure the element is visible - this is equivalent to jquery's is(':visible')
-  private _isVisible = (elem: any) => !!( elem.offsetWidth || elem.offsetHeight || (typeof elem.getClientRects === 'function' && elem.getClientRects().length )))
+  private _isVisible = (elem: any) => !!( elem.offsetWidth || elem.offsetHeight || (typeof elem.getClientRects === 'function' && elem.getClientRects().length )));
 
   // Recaptcha client is a nested, circular object with object keys that seem generated
   // We flatten that object a couple of levels deep for easy access to certain keys we're interested in.
@@ -329,3 +329,4 @@ export class RecaptchaContentScript {
     "error": null
 }
 */
+p

--- a/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
@@ -29,8 +29,7 @@ export class RecaptchaContentScript {
     props.reduce((a, e) => ({ ...a, [e]: o[e] }), {})
 
   // make sure the element is visible - this is equivalent to jquery's is(':visible')
-  private _isVisible = (elem: any) =>
-    !!( elem.offsetWidth || elem.offsetHeight || (typeof elem.getClientRects === 'function' && elem.getClientRects().length ));
+  private _isVisible = (elem: any) => !!( elem.offsetWidth || elem.offsetHeight || (typeof elem.getClientRects === 'function' && elem.getClientRects().length ));
 
   // Recaptcha client is a nested, circular object with object keys that seem generated
   // We flatten that object a couple of levels deep for easy access to certain keys we're interested in.
@@ -330,4 +329,3 @@ export class RecaptchaContentScript {
     "error": null
 }
 */
-p

--- a/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
@@ -28,6 +28,9 @@ export class RecaptchaContentScript {
   private _pick = (props: any[]) => (o: any) =>
     props.reduce((a, e) => ({ ...a, [e]: o[e] }), {})
 
+  // make sure the element is visible - this is equivalent to jquery's is(':visible')
+  private _isVisible = (elem: any) => !!( elem.offsetWidth || elem.offsetHeight || (typeof elem.getClientRects === 'function' && elem.getClientRects().length )))
+
   // Recaptcha client is a nested, circular object with object keys that seem generated
   // We flatten that object a couple of levels deep for easy access to certain keys we're interested in.
   private _flattenObject(item: any, levels = 2, ignoreHTML = true) {
@@ -125,7 +128,7 @@ export class RecaptchaContentScript {
   private getVisibleIframesIds() {
     // Find all visible recaptcha boxes through their iframes
     return this._findVisibleIframeNodes()
-      .filter($f => !$f.src.includes('invisible'))
+      .filter($f => this._isVisible($f))
       .map($f => this._paintCaptchaBusy($f))
       .filter($f => $f && $f.getAttribute('name'))
       .map($f => $f.getAttribute('name') || '') // a-841543e13666

--- a/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
@@ -29,7 +29,8 @@ export class RecaptchaContentScript {
     props.reduce((a, e) => ({ ...a, [e]: o[e] }), {})
 
   // make sure the element is visible - this is equivalent to jquery's is(':visible')
-  private _isVisible = (elem: any) => !!( elem.offsetWidth || elem.offsetHeight || (typeof elem.getClientRects === 'function' && elem.getClientRects().length )));
+  private _isVisible = (elem: any) =>
+    !!( elem.offsetWidth || elem.offsetHeight || (typeof elem.getClientRects === 'function' && elem.getClientRects().length ));
 
   // Recaptcha client is a nested, circular object with object keys that seem generated
   // We flatten that object a couple of levels deep for easy access to certain keys we're interested in.


### PR DESCRIPTION
This PR fixes #300 

Captchas with 'invisible' in the src can be shown via js, at which point the plugin fails to find them.

My patch uses something equivalent to jquery's `is(':visible')` to check whether the captcha is visible to the user, rather than relying on the src value.