### PR TITLE
Fix enabledPlugin typo, plugins[i].length, add tests

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.js
@@ -52,7 +52,7 @@ class Plugin extends PuppeteerExtraPlugin {
           pluginData.__mimeTypes.forEach((type, index) => {
             plugins[pluginData.name][index] = mimeTypes[type]
             plugins[type] = mimeTypes[type]
-            Object.defineProperty(mimeTypes[type], 'enabledPlugins', {
+            Object.defineProperty(mimeTypes[type], 'enabledPlugin', {
               value: JSON.parse(JSON.stringify(plugins[pluginData.name])),
               writable: false,
               enumerable: false, // Important: `JSON.stringify(navigator.plugins)`

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.test.js
@@ -37,20 +37,6 @@ test('stealth: has plugin, has mimetypes', async t => {
   t.is(mimeTypes.length, 4)
 })
 
-test('stealth: enabledPlugin works', async t => {
-  const puppeteer = addExtra(vanillaPuppeteer).use(Plugin())
-  const browser = await puppeteer.launch({ headless: true })
-  const page = await browser.newPage()
-
-  const test = await page.evaluate(_ => {
-    try {
-      return navigator.mimeTypes[0].enabledPlugin
-    } catch (e) {}
-  })
-
-  t.deepEqual(test, { '0': {} })
-})
-
 test('stealth: will not leak modifications', async t => {
   const puppeteer = addExtra(vanillaPuppeteer).use(Plugin())
   const browser = await puppeteer.launch({ headless: true })
@@ -67,4 +53,9 @@ test('stealth: will not leak modifications', async t => {
     () => Object.getOwnPropertyNames(navigator) // Must be an empty array if native
   )
   t.deepEqual(test2, [])
+
+  const test3 = await page.evaluate(
+    _ => navigator.mimeTypes[0].enabledPlugin // should not throw an error
+  )
+  t.deepEqual(test3, { '0': {} })
 })

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.test.js
@@ -63,4 +63,15 @@ test('stealth: will not leak modifications', async t => {
     _ => navigator.mimeTypes['application/pdf'].enabledPlugin // should not throw an error
   )
   t.deepEqual(test4, { '0': {} })
+
+  const test5 = await page.evaluate(
+    _ => navigator.plugins[0].length
+  )
+  t.deepEqual(test5, 1)
+
+  const test6 = await page.evaluate(
+    _ => navigator.mimeTypes[0].length
+  )
+  t.is(test6, undefined)
+
 })

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.test.js
@@ -58,4 +58,9 @@ test('stealth: will not leak modifications', async t => {
     _ => navigator.mimeTypes[0].enabledPlugin // should not throw an error
   )
   t.deepEqual(test3, { '0': {} })
+
+  const test4 = await page.evaluate(
+    _ => navigator.mimeTypes['application/pdf'].enabledPlugin // should not throw an error
+  )
+  t.deepEqual(test4, { '0': {} })
 })

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.test.js
@@ -69,4 +69,7 @@ test('stealth: will not leak modifications', async t => {
 
   const test6 = await page.evaluate(_ => navigator.mimeTypes[0].length)
   t.is(test6, undefined)
+
+  const test7 = await page.evaluate(_ => Object.getOwnPropertyDescriptor(navigator.plugins[0], 'length'))
+  t.is(test7, undefined)
 })

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.test.js
@@ -37,6 +37,20 @@ test('stealth: has plugin, has mimetypes', async t => {
   t.is(mimeTypes.length, 4)
 })
 
+test('stealth: enabledPlugin works', async t => {
+  const puppeteer = addExtra(vanillaPuppeteer).use(Plugin())
+  const browser = await puppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+
+  const test = await page.evaluate(_ => {
+    try {
+      return navigator.mimeTypes[0].enabledPlugin
+    } catch (e) {}
+  })
+
+  t.deepEqual(test, { '0': {} })
+})
+
 test('stealth: will not leak modifications', async t => {
   const puppeteer = addExtra(vanillaPuppeteer).use(Plugin())
   const browser = await puppeteer.launch({ headless: true })

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.test.js
@@ -64,14 +64,9 @@ test('stealth: will not leak modifications', async t => {
   )
   t.deepEqual(test4, { '0': {} })
 
-  const test5 = await page.evaluate(
-    _ => navigator.plugins[0].length
-  )
+  const test5 = await page.evaluate(_ => navigator.plugins[0].length)
   t.deepEqual(test5, 1)
 
-  const test6 = await page.evaluate(
-    _ => navigator.mimeTypes[0].length
-  )
+  const test6 = await page.evaluate(_ => navigator.mimeTypes[0].length)
   t.is(test6, undefined)
-
 })

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/magicArray.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/magicArray.js
@@ -31,6 +31,12 @@ module.exports.generateMagicArray = (utils, fns) =>
         }
         defineProp(item, prop, data[prop])
       }
+
+      // navigator.plugins[i].length should always be 1
+      if (itemProto === Plugin.prototype) {
+        defineProp(item, "length", 1)
+      }
+
       // We need to spoof a specific `MimeType` or `Plugin` object
       return Object.create(itemProto, Object.getOwnPropertyDescriptors(item))
     }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/magicArray.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/magicArray.js
@@ -34,7 +34,7 @@ module.exports.generateMagicArray = (utils, fns) =>
 
       // navigator.plugins[i].length should always be 1
       if (itemProto === Plugin.prototype) {
-        defineProp(item, 'length', 1)
+        defineProp(item, 'length', data.__mimeTypes.length)
       }
 
       // We need to spoof a specific `MimeType` or `Plugin` object

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/magicArray.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/magicArray.js
@@ -1,4 +1,4 @@
-/* global MimeType MimeTypeArray PluginArray  */
+/* global MimeType MimeTypeArray Plugin PluginArray  */
 
 /**
  * Generate a convincing and functional MimeType or Plugin array from scratch.
@@ -34,7 +34,7 @@ module.exports.generateMagicArray = (utils, fns) =>
 
       // navigator.plugins[i].length should always be 1
       if (itemProto === Plugin.prototype) {
-        defineProp(item, "length", 1)
+        defineProp(item, 'length', 1)
       }
 
       // We need to spoof a specific `MimeType` or `Plugin` object

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/magicArray.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/magicArray.js
@@ -32,7 +32,7 @@ module.exports.generateMagicArray = (utils, fns) =>
         defineProp(item, prop, data[prop])
       }
 
-      // navigator.plugins[i].length should always be 1
+      // navigator.plugins[i].length should always be the length of the mimeTypes array
       if (itemProto === Plugin.prototype) {
         defineProp(item, 'length', data.__mimeTypes.length)
       }


### PR DESCRIPTION
This fixes a typo: `enabledPlugins` should be `enabledPlugin`. Test case added as well.

Thanks to @momala454 for reporting