### PR TITLE
Fix iframe.contentWindow.document issues

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.js
@@ -37,6 +37,10 @@ class Plugin extends PuppeteerExtraPlugin {
               if (key === 'self') {
                 return this
               }
+              // iframe.contentWindow.document === iframe.contentDocument // must be true
+              if (key === 'document') {
+                return iframe.contentDocument || iframe.contentWindow.document
+              }
               // iframe.contentWindow.frameElement === iframe // must be true
               if (key === 'frameElement') {
                 return iframe

--- a/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.test.js
@@ -7,9 +7,8 @@ const {
   vanillaPuppeteer,
   addExtra
 } = require('../../test/util')
-// const Plugin = require('.')
 // NOTE: We're using the full plugin for testing here as `iframe.contentWindow` uses data set by `chrome.runtime`
-const Plugin = require('puppeteer-extra-plugin-stealth')
+const Plugin = require('../..')
 
 // Fix CI issues with old versions
 const isOldPuppeteerVersion = () => {
@@ -44,14 +43,18 @@ test('stealth: will not break iframes', async t => {
     body.appendChild(iframe)
   }, testFuncReturnValue)
   const realReturn = await page.evaluate(
-    () => document.querySelector('iframe').contentWindow.mySuperFunction() // eslint-disable-line
+    _ => document.querySelector('iframe').contentWindow.mySuperFunction() // eslint-disable-line
+  )
+  const realText = await page.evaluate(
+    _ => document.querySelector('iframe').contentWindow.document.body.innerText
   )
   await browser.close()
 
   t.is(realReturn, 'TESTSTRING')
+  t.is(realText, 'foobar')
 })
 
-test('vanilla: will not have chrome runtine in any frame', async t => {
+test('vanilla: will not have chrome runtime in any frame', async t => {
   const browser = await vanillaPuppeteer.launch({ headless: true })
   const page = await browser.newPage()
 


### PR DESCRIPTION
This should fix the issues seen in e.g. Doubleclick tags.

Thanks to: https://github.com/berstend/puppeteer-extra/issues/202#issuecomment-645300106 https://github.com/berstend/puppeteer-extra/issues/137#issuecomment-693435327 https://github.com/berstend/puppeteer-extra/issues/324#issuecomment-693452497 @phyks @trnj

Note that the test fails because `iframe.srcdoc` setter is not working - has it ever worked?