### PR TITLE
feat: use puppeteer-core instead of puppeteer

### DIFF
--- a/packages/puppeteer-extra/package.json
+++ b/packages/puppeteer-extra/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@types/puppeteer": "^2.0.0",
+    "@types/puppeteer-core": "^2.0.0",
     "ava": "^2.4.0",
     "documentation-markdown-themes": "^12.1.5",
     "npm-run-all": "^4.1.5",
@@ -60,11 +61,11 @@
     "typescript": "^3.7.4"
   },
   "peerDependencies": {
-    "puppeteer": "*"
+    "puppeteer-core": "*"
   },
   "dependencies": {
     "@types/debug": "^4.1.0",
-    "@types/puppeteer": "*",
+    "@types/puppeteer-core": "*",
     "debug": "^4.1.1",
     "deepmerge": "^4.2.2"
   },

--- a/packages/puppeteer-extra/src/puppeteer.ts
+++ b/packages/puppeteer-extra/src/puppeteer.ts
@@ -1,10 +1,10 @@
 // A wildcard import would result in a `require("puppeteer")` statement
 // at the top of the transpiled js file, not what we want. :-/
 
-export { Browser } from 'puppeteer'
-export { Page } from 'puppeteer'
-export { ConnectOptions } from 'puppeteer'
-export { ChromeArgOptions } from 'puppeteer'
-export { LaunchOptions } from 'puppeteer'
-export { FetcherOptions } from 'puppeteer'
-export { BrowserFetcher } from 'puppeteer'
+export { Browser } from 'puppeteer-core'
+export { Page } from 'puppeteer-core'
+export { ConnectOptions } from 'puppeteer-core'
+export { ChromeArgOptions } from 'puppeteer-core'
+export { LaunchOptions } from 'puppeteer-core'
+export { FetcherOptions } from 'puppeteer-core'
+export { BrowserFetcher } from 'puppeteer-core'


### PR DESCRIPTION
This should address https://github.com/berstend/puppeteer-extra/issues/262 https://github.com/berstend/puppeteer-extra/issues/27 https://github.com/berstend/puppeteer-extra/issues/30 https://github.com/berstend/puppeteer-extra/issues/66 

It seems this package is the `puppeteer` types rather than its functionality to download browser.