### PR TITLE
Add ElementHandle re-export from puppeteer

### DIFF
--- a/packages/puppeteer-extra/src/puppeteer.ts
+++ b/packages/puppeteer-extra/src/puppeteer.ts
@@ -3,6 +3,7 @@
 
 export { Browser } from 'puppeteer'
 export { Page } from 'puppeteer'
+export { ElementHandle } from 'puppeteer'
 export { ConnectOptions } from 'puppeteer'
 export { ChromeArgOptions } from 'puppeteer'
 export { LaunchOptions } from 'puppeteer'


### PR DESCRIPTION
TypeScript requires puppeteer types to be from the same package