### PR TITLE
fix(plugin-stealth): Improve navigator.plugin evasion

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.js
@@ -51,12 +51,18 @@ class Plugin extends PuppeteerExtraPlugin {
         for (const pluginData of data.plugins) {
           pluginData.__mimeTypes.forEach((type, index) => {
             plugins[pluginData.name][index] = mimeTypes[type]
-            plugins[type] = mimeTypes[type]
-            Object.defineProperty(mimeTypes[type], 'enabledPlugins', {
-              value: JSON.parse(JSON.stringify(plugins[pluginData.name])),
+
+            Object.defineProperty(plugins[pluginData.name], type, {
+              value: mimeTypes[type],
+              writable: false,
+              enumerable: false, // Not enumerable
+              configurable: true
+            })
+            Object.defineProperty(mimeTypes[type], 'enabledPlugin', {
+              value: new Proxy(plugins[pluginData.name], {}), // Prevent circular references
               writable: false,
               enumerable: false, // Important: `JSON.stringify(navigator.plugins)`
-              configurable: false
+              configurable: true
             })
           })
         }
@@ -87,6 +93,6 @@ class Plugin extends PuppeteerExtraPlugin {
   }
 }
 
-module.exports = function(pluginConfig) {
+module.exports = function (pluginConfig) {
   return new Plugin(pluginConfig)
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.js
@@ -93,6 +93,6 @@ class Plugin extends PuppeteerExtraPlugin {
   }
 }
 
-module.exports = function (pluginConfig) {
+module.exports = function(pluginConfig) {
   return new Plugin(pluginConfig)
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/magicArray.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/magicArray.js
@@ -7,7 +7,7 @@
  * Note: This is meant to be run in the context of the page.
  */
 module.exports.generateMagicArray = (utils, fns) =>
-  function (
+  function(
     dataArray = [],
     proto = MimeTypeArray.prototype,
     itemProto = MimeType.prototype,

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/mimeTypes.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/mimeTypes.test.js
@@ -11,7 +11,7 @@ test('stealth: will have convincing mimeTypes', async t => {
 
   const results = await page.evaluate(() => {
     // We need to help serializing the error or it won't survive being sent back from `page.evaluate`
-    const catchErr = function(fn, ...args) {
+    const catchErr = function (fn, ...args) {
       try {
         return fn.apply(this, args)
       } catch ({ name, message, stack }) {
@@ -33,6 +33,10 @@ test('stealth: will have convincing mimeTypes', async t => {
         json: JSON.stringify(navigator.mimeTypes),
         hasPropPush: 'push' in navigator.mimeTypes,
         hasPropLength: 'length' in navigator.mimeTypes,
+        hasLengthDescriptor: !!Object.getOwnPropertyDescriptor(
+          navigator.mimeTypes,
+          'length'
+        ),
         propertyNames: JSON.stringify(
           Object.getOwnPropertyNames(navigator.mimeTypes)
         ),
@@ -40,11 +44,11 @@ test('stealth: will have convincing mimeTypes', async t => {
           'length'
         ),
         keys: JSON.stringify(Object.keys(navigator.mimeTypes)),
-        namedPropsAuthentic: (function() {
+        namedPropsAuthentic: (function () {
           navigator.mimeTypes.alice = 'bob'
           return navigator.mimeTypes.namedItem('alice') === null // true on chrome
         })(),
-        loopResult: (function() {
+        loopResult: (function () {
           let res = ''
           for (var bK = 0; bK < window.navigator.mimeTypes.length; bK++)
             bK === window.navigator.mimeTypes.length - 1
@@ -104,6 +108,7 @@ test('stealth: will have convincing mimeTypes', async t => {
     exists: true,
     hasPropPush: false,
     hasPropLength: true,
+    hasLengthDescriptor: false,
     isArray: false,
     json: `{"0":{},"1":{},"2":{},"3":{}}`,
     keys: `["0","1","2","3"]`,
@@ -164,13 +169,40 @@ test('stealth: will have convincing mimeType entry', async t => {
       exists: !!navigator.mimeTypes[0],
       toString: navigator.mimeTypes[0].toString(),
       toStringProto: navigator.mimeTypes[0].__proto__.toString(), // eslint-disable-line no-proto
-      protoSymbol: navigator.mimeTypes[0].__proto__[Symbol.toStringTag] // eslint-disable-line no-proto
+      protoSymbol: navigator.mimeTypes[0].__proto__[Symbol.toStringTag], // eslint-disable-line no-proto
+      enabledPlugin: !!navigator.mimeTypes[0].enabledPlugin, // should not throw
+      enabledPlugin2: !!navigator.mimeTypes['application/pdf'].enabledPlugin, // should not throw
+      enabledPlugins: !!navigator.mimeTypes[0].enabledPlugins, // regression: should not exist (anymore)
+      pdfPlugin: JSON.stringify(
+        navigator.mimeTypes['application/pdf'].enabledPlugin
+      ),
+      length: !!navigator.mimeTypes[0].length, // should not throw and return mimeTypes length
+      lengthDescriptor: !!Object.getOwnPropertyDescriptor(
+        navigator.mimeTypes[0],
+        'length'
+      ),
+      json: JSON.stringify(navigator.mimeTypes[0]),
+      propertyNames: JSON.stringify(
+        Object.getOwnPropertyNames(navigator.mimeTypes[0])
+      ),
+      nested:
+        navigator.mimeTypes['application/pdf'].enabledPlugin[0].enabledPlugin[0]
+          .enabledPlugin[0].enabledPlugin[0].enabledPlugin[0].suffixes
     }
   }))
   t.deepEqual(results.mimeType, {
     exists: true,
     protoSymbol: 'MimeType',
     toString: '[object MimeType]',
-    toStringProto: '[object MimeType]'
+    toStringProto: '[object MimeType]',
+    enabledPlugin: true,
+    enabledPlugin2: true,
+    enabledPlugins: false,
+    pdfPlugin: '{"0":{}}',
+    length: false,
+    lengthDescriptor: false,
+    json: '{}',
+    propertyNames: '[]',
+    nested: 'pdf'
   })
 })

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/mimeTypes.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/mimeTypes.test.js
@@ -11,7 +11,7 @@ test('stealth: will have convincing mimeTypes', async t => {
 
   const results = await page.evaluate(() => {
     // We need to help serializing the error or it won't survive being sent back from `page.evaluate`
-    const catchErr = function (fn, ...args) {
+    const catchErr = function(fn, ...args) {
       try {
         return fn.apply(this, args)
       } catch ({ name, message, stack }) {
@@ -44,11 +44,11 @@ test('stealth: will have convincing mimeTypes', async t => {
           'length'
         ),
         keys: JSON.stringify(Object.keys(navigator.mimeTypes)),
-        namedPropsAuthentic: (function () {
+        namedPropsAuthentic: (function() {
           navigator.mimeTypes.alice = 'bob'
           return navigator.mimeTypes.namedItem('alice') === null // true on chrome
         })(),
-        loopResult: (function () {
+        loopResult: (function() {
           let res = ''
           for (var bK = 0; bK < window.navigator.mimeTypes.length; bK++)
             bK === window.navigator.mimeTypes.length - 1

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/plugins.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/plugins.test.js
@@ -11,7 +11,7 @@ test('stealth: will have convincing plugins', async t => {
 
   const results = await page.evaluate(() => {
     // We need to help serializing the error or it won't survive being sent back from `page.evaluate`
-    const catchErr = function(fn, ...args) {
+    const catchErr = function (fn, ...args) {
       try {
         return fn.apply(this, args)
       } catch ({ name, message, stack }) {
@@ -33,6 +33,10 @@ test('stealth: will have convincing plugins', async t => {
         json: JSON.stringify(navigator.plugins),
         hasPropPush: 'push' in navigator.plugins,
         hasPropLength: 'length' in navigator.plugins,
+        hasLengthDescriptor: !!Object.getOwnPropertyDescriptor(
+          navigator.plugins,
+          'length'
+        ),
         propertyNames: JSON.stringify(
           Object.getOwnPropertyNames(navigator.plugins)
         ),
@@ -89,6 +93,7 @@ test('stealth: will have convincing plugins', async t => {
   t.deepEqual(results.plugins, {
     exists: true,
     hasPropLength: true,
+    hasLengthDescriptor: false,
     hasPropPush: false,
     isArray: false,
     json: `{"0":{"0":{}},"1":{"0":{}},"2":{"0":{},"1":{}}}`,
@@ -143,17 +148,37 @@ test('stealth: will have convincing plugin entry', async t => {
   const page = await browser.newPage()
 
   const results = await page.evaluate(() => ({
-    mimeType: {
+    plugins: {
       exists: !!navigator.plugins[0],
       toString: navigator.plugins[0].toString(),
       toStringProto: navigator.plugins[0].__proto__.toString(), // eslint-disable-line no-proto
-      protoSymbol: navigator.plugins[0].__proto__[Symbol.toStringTag] // eslint-disable-line no-proto
+      protoSymbol: navigator.plugins[0].__proto__[Symbol.toStringTag], // eslint-disable-line no-proto
+      length: navigator.plugins[0].length, // should not throw and return mimeTypes length
+      lengthDescriptor: Object.getOwnPropertyDescriptor(
+        navigator.plugins[0],
+        'length'
+      )
+    },
+    plugin: {
+      mtIndex: !!navigator.plugins[0][0], // mimeType should be accessible through index
+      mtNamed: !!navigator.plugins[0]['application/x-google-chrome-pdf'], // mimeType should be accessible through name
+      json: JSON.stringify(navigator.plugins[0]),
+      propertyNames: JSON.stringify(
+        Object.getOwnPropertyNames(navigator.plugins[0])
+      )
     }
   }))
-  t.deepEqual(results.mimeType, {
+  t.deepEqual(results.plugins, {
     exists: true,
     protoSymbol: 'Plugin',
     toString: '[object Plugin]',
-    toStringProto: '[object Plugin]'
+    toStringProto: '[object Plugin]',
+    length: 1
+  })
+  t.deepEqual(results.plugin, {
+    mtIndex: true,
+    mtNamed: true,
+    json: '{"0":{}}',
+    propertyNames: '["0","application/x-google-chrome-pdf"]'
   })
 })

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/plugins.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/plugins.test.js
@@ -11,7 +11,7 @@ test('stealth: will have convincing plugins', async t => {
 
   const results = await page.evaluate(() => {
     // We need to help serializing the error or it won't survive being sent back from `page.evaluate`
-    const catchErr = function (fn, ...args) {
+    const catchErr = function(fn, ...args) {
       try {
         return fn.apply(this, args)
       } catch ({ name, message, stack }) {

--- a/packages/puppeteer-extra-plugin-stealth/readme.md
+++ b/packages/puppeteer-extra-plugin-stealth/readme.md
@@ -85,6 +85,8 @@ If something new comes up or you experience a problem, please do your homework a
 
 ## Changelog
 
+🎁 **Note:** Until we've automated changelog updates in readmes please follow the `#announcements` channel in our [discord server](https://discord.gg/vz7PeKk) for updates and changelog info.
+
 #### `v2.4.7`
 
 - New: `user-agent-override` - Used to set a stealthy UA string, language & platform. This also fixes issues with the prior method of setting the `Accept-Language` header through request interception ([#104](https://github.com/berstend/puppeteer-extra/pull/104), kudos to [@Niek](https://github.com/Niek))


### PR DESCRIPTION
This PR is based on #312 by @Niek and fixes/improves various issues with the `navigator.plugins` and `navigator.mimetypes` evasion.

This abomination is also now possible 😄 

```js
navigator.mimeTypes['application/pdf'].enabledPlugin[0].enabledPlugin[0]
 .enabledPlugin[0].enabledPlugin[0].enabledPlugin[0].enabledPlugin[0].suffixes
// => pdf
```