### PR TITLE
feat(plugin-recaptcha): Hide captcha window after solving

### DIFF
--- a/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
@@ -115,6 +115,26 @@ export class RecaptchaContentScript {
     )
   }
 
+  private _hideChallengeWindowIfPresent(id?: string) {
+    let frame: HTMLElement | null = document.querySelector<HTMLIFrameElement>(
+      `iframe[src^='https://www.google.com/recaptcha/api2/bframe'][name^="c-${id ||
+        ''}"]`
+    )
+    if (!frame) {
+      return
+    }
+    while (
+      frame &&
+      frame.parentElement &&
+      frame.parentElement !== document.body
+    ) {
+      frame = frame.parentElement
+    }
+    if (frame) {
+      frame.style.visibility = 'hidden'
+    }
+  }
+
   private getClients() {
     // Bail out early if there's no indication of recaptchas
     if (!window || !window.__google_recaptcha_client) return
@@ -251,6 +271,8 @@ export class RecaptchaContentScript {
             solved.error = `Solution not found for id '${solved.id}'`
             return solved
           }
+          // Hide if present challenge window
+          this._hideChallengeWindowIfPresent(solved.id);
           // Enter solution in response textarea
           const $input = this.getResponseInputById(solved.id)
           if ($input) {


### PR DESCRIPTION
All credits of this PR goes to @nsourov.

Currently, the plugin does not close the recaptcha window after solving it. I guess that in most cases the behavior is fine.

In my situation, the recaptcha window is opening on top of a button that I need to click, and what happens is that Puppeteer clicks the mouse at the position of the button, but since the recaptcha window is open, it clicks the recaptcha window and not the desired button.

This PR simply closes the recaptcha after solving it correctly.