### PR TITLE
feat(plugin-stealth): Add webdriver fix for Chrome >= 88.0.4291.0

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.webdriver/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.webdriver/index.js
@@ -15,10 +15,16 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/navigator.webdriver'
   }
 
+  // Pre Chrome 88.0.4291.0
   async onPageCreated(page) {
     await page.evaluateOnNewDocument(() => {
       delete Object.getPrototypeOf(navigator).webdriver
     })
+  }
+
+  // Post Chrome 88.0.4291.0
+  async beforeLaunch(options) {
+    options.args.push(`--disable-blink-features=AutomationControlled`)
   }
 }
 

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.webdriver/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.webdriver/index.js
@@ -23,7 +23,16 @@ class Plugin extends PuppeteerExtraPlugin {
   }
 
   // Post Chrome 88.0.4291.0
+  // Note: this will add an infobar to Chrome with a warning that an unsupported flag is set
+  // To remove this bar on Linux, run: mkdir -p /etc/opt/chrome/policies/managed && echo '{ "CommandLineFlagSecurityWarningsEnabled": false }' > /etc/opt/chrome/policies/managed/managed_policies.json
   async beforeLaunch(options) {
+    // If disable-blink-features is already passed, append the AutomationControlled switch
+    options.args.forEach(e => {
+      if (e.startsWith('--disable-blink-features=')) {
+        e += ',AutomationControlled'
+        return // eslint-disable-line
+      }
+    })
     options.args.push(`--disable-blink-features=AutomationControlled`)
   }
 }


### PR DESCRIPTION
To test, run:
```
PUPPETEER_EXECUTABLE_PATH=/path/to/chrome-unstable yarn run test
```