### PR TITLE
Add the name of the evasion on the output of extract-stealth-evasions

### DIFF
--- a/packages/extract-stealth-evasions/index.js
+++ b/packages/extract-stealth-evasions/index.js
@@ -83,6 +83,13 @@ puppeteer
   })
 
 function patchEval(f, args) {
+  if (argv.minify !== true) {
+    let reg = (new Error()).stack.match(/\/evasions\/(?!_utils)([^\/]+)\//);
+    if (reg)
+      scripts += '\n\n/**\nEVASION '+reg[1]+'\n**/\n';
+    else
+      scripts += '\n\n/**\nEVASION\n**/\n';
+  }
   // Check if there are options supplied
   if (typeof args !== 'undefined') {
     scripts += '(' + f.toString() + ')(' + JSON.stringify(args) + ');\n'


### PR DESCRIPTION
If the beautify is disabled, the index.js file will contains the name of the evasion. This allow to more easily know which evasion we're currently viewing.
Like this ; 
```js
/**
EVASION chrome.app
**/
(({ _utilsFns, _mainFunction, _args }) => {
        // Add this point we cannot use our utililty functions as they're just strings, we need to materialize them first
        const utils = Object.fromEntries(
          Object.entries(_utilsFns).map(([key, value]) => [key, eval(value)]) // eslint-disable-line no-eval
        )
        utils.preloadCache()
        return eval(_mainFunction)(utils, ..._args) // eslint-disable-line no-eval
      })({"_utilsFns":{"stripProxyFromErrors":"(handler = {}) => {\n  const newHandler = {}\n  // We wrap each trap in the handler in a try/catch and modify the error stack if they throw\n  const traps = Object.getOwnPropertyNames(handler)\n  traps.forEach(trap => {\n    newHandler[trap] = function() {\n      try {\n        // Forward the call to the defined proxy handler\n        return handler[trap].apply(this, arguments || [])\n      } catch (err) {\n        // Stack traces differ per browser, we only support chromium based ones currently\n        if (!err || !err.stack || !err.stack.includes(`at `)) {\n          throw err\n        }\n\n        // When something throws within one of our traps the Proxy will show up in error stacks\n        // An earlier implementation of this code would simply strip lines with a blacklist,\n        // but it makes sense to be more surgical here and only remove lines related to our Proxy.\n        // We try to use a known \"anchor\" line for that and strip it with everything above it.\n        // If the anchor line cannot be found for some reason we fall back to our blacklist approach.\n\n        const stripWithBlacklist = stack => {\n          const blacklist = [\n            `at Reflect.${trap} `, // e.g. Reflect.get or Reflect.apply\n            `at Object.${trap} `, // e.g. Object.get or Object.apply\n            `at Object.newHandler.<computed> [as ${trap}] ` // caused by this very wrapper :-)\n          ]\n          return (\n            err.stack\n              .split('\\n')\n              // Always remove the first (file) line in the stack (guaranteed to be our proxy)\n              .filter((line, index) => index !== 1)\n              // Check if the line starts with one of our blacklisted strings\n              .filter(line => !blacklist.some(bl => line.trim().startsWith(bl)))\n              .join('\\n')\n          )\n        }\n\n        const stripWithAnchor = stack => {\n          const stackArr = stack.split('\\n')\n          const anchor = `at Object.newHandler.<computed> [as ${trap}] ` // Known fir(...)
```