### PR TITLE
feat(plugin-recaptcha): Improve support for invisible reCAPTCHAs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-error.log*
 TODO.md
 packages/testing/
 packages/puppeteer-extra2/
+packages/puppeteer-extra-old/
 packages/test-*
 
 testing/

--- a/packages/puppeteer-extra-plugin-recaptcha/src/index.test.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/index.test.ts
@@ -37,4 +37,25 @@ test('will detect captchas', async (t) => {
   await browser.close()
 })
 
+test('will not throw when no captchas are found', async (t) => {
+  const puppeteer = addExtra(require('puppeteer'))
+  const recaptchaPlugin = RecaptchaPlugin()
+  puppeteer.use(recaptchaPlugin)
+
+  const browser = await puppeteer.launch({
+    args: PUPPETEER_ARGS,
+    headless: true,
+  })
+  const page = await browser.newPage()
+
+  const url = 'https://www.example.com'
+  await page.goto(url, { waitUntil: 'networkidle0' })
+
+  const { captchas, error } = await (page as any).findRecaptchas()
+  t.is(error, null)
+  t.is(captchas.length, 0)
+
+  await browser.close()
+})
+
 // TODO: test/mock the rest


### PR DESCRIPTION
This PR:
- adds improved support for detecting (and solving) invisible reCAPTCHAs, especially if the challenge is programmatically invoked
  - In addition to looking for visible reCAPTCHA iframes we're now looking for invisible ones as well, but filter them by checking if there's an active challenge window open for them (otherwise we would get false positives and duplicates)
- adds an additional test making sure the plugin doesn't throw in case no captchas are found

Reference:
https://developers.google.com/recaptcha/docs/invisible#programmatic_execute

Potentially fixes #162 