### PR TITLE
Updated @cliqz/adblocker-puppeteer to 1.18.6 fix Memory leak

### DIFF
--- a/packages/puppeteer-extra-plugin-adblocker/package.json
+++ b/packages/puppeteer-extra-plugin-adblocker/package.json
@@ -56,7 +56,7 @@
     "typescript": "^3.7.4"
   },
   "dependencies": {
-    "@cliqz/adblocker-puppeteer": "^1.4.0",
+    "@cliqz/adblocker-puppeteer": "^1.18.6",
     "@types/chrome": "0.0.91",
     "debug": "^4.1.1",
     "node-fetch": "^2.6.0",


### PR DESCRIPTION
Page object being Memory Leaked inside PuppeteerExtraPluginAdblocker
Issue: https://github.com/cliqz-oss/adblocker/issues/1449#issuecomment-730234360

Fixes https://github.com/berstend/puppeteer-extra/issues/375