### PR TITLE
Catch uncaught exceptions in _onTargetCreated

### DIFF
--- a/packages/puppeteer-extra-plugin/src/index.ts
+++ b/packages/puppeteer-extra-plugin/src/index.ts
@@ -531,13 +531,17 @@ export abstract class PuppeteerExtraPlugin {
    * @private
    */
   async _onTargetCreated(target: Puppeteer.Target) {
-    if (this.onTargetCreated) await this.onTargetCreated(target)
-    // Pre filter pages for plugin developers convenience
-    if (target.type() === 'page') {
-      const page = await target.page()
-      if (this.onPageCreated) {
-        await this.onPageCreated(page)
+    try {
+      if (this.onTargetCreated) await this.onTargetCreated(target)
+      // Pre filter pages for plugin developers convenience
+      if (target.type() === 'page') {
+        const page = await target.page()
+        if (this.onPageCreated) {
+          await this.onPageCreated(page)
+        }
       }
+    } catch (err) {
+      this.debug(`_onTargetCreated: caught error: ${err.message}`}
     }
   }
 

--- a/packages/puppeteer-extra-plugin/src/index.ts
+++ b/packages/puppeteer-extra-plugin/src/index.ts
@@ -541,7 +541,7 @@ export abstract class PuppeteerExtraPlugin {
         }
       }
     } catch (err) {
-      this.debug(`_onTargetCreated: caught error: ${err.message}`}
+      this.debug(`_onTargetCreated: caught error: ${err.message}`);
     }
   }
 


### PR DESCRIPTION
Getting lots of uncaught exceptions running in production when puppeteer-extra plugins try to access a page/target that is created and then destroyed instantly (for example if browser is redirected), this change will catch those exceptions. 
e.g the puppeteer-extra-recaptcha plugin calls `page.setBypassCSP` inside its onPageCreated event handler, but sometimes the page is no longer available, leading to lots of `Protocol error (Page.setBypassCSP): Target closed.` uncaught exceptions.