### PR TITLE
feat(plugin-recaptcha): Add support for hCaptcha

### DIFF
--- a/packages/puppeteer-extra-plugin-recaptcha/package.json
+++ b/packages/puppeteer-extra-plugin-recaptcha/package.json
@@ -1,7 +1,7 @@
 {
   "name": "puppeteer-extra-plugin-recaptcha",
   "version": "3.2.2",
-  "description": "A puppeteer-extra plugin to solve reCAPTCHAs automatically.",
+  "description": "A puppeteer-extra plugin to solve reCAPTCHAs and hCaptchas automatically.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "typings": "dist/index.d.ts",
@@ -42,6 +42,7 @@
     "puppeteer-extra",
     "puppeteer-extra-plugin",
     "recaptcha",
+    "hcaptcha",
     "captcha",
     "2captcha"
   ],

--- a/packages/puppeteer-extra-plugin-recaptcha/readme.md
+++ b/packages/puppeteer-extra-plugin-recaptcha/readme.md
@@ -1,6 +1,6 @@
 # puppeteer-extra-plugin-recaptcha [![Build Status](https://travis-ci.org/berstend/puppeteer-extra.svg?branch=master)](https://travis-ci.org/berstend/puppeteer-extra) [![npm](https://img.shields.io/npm/v/puppeteer-extra-plugin-recaptcha.svg)](https://www.npmjs.com/package/puppeteer-extra-plugin-recaptcha)
 
-> A [puppeteer-extra](https://github.com/berstend/puppeteer-extra) plugin to solve reCAPTCHAs automatically.
+> A [puppeteer-extra](https://github.com/berstend/puppeteer-extra) plugin to solve reCAPTCHAs and hCaptchas automatically.
 
 ![](https://i.imgur.com/SWrIQw0.gif)
 
@@ -150,6 +150,8 @@ The stated reasons for this omnipresent captcha plague vary from site owners hav
 
 In any case I strongly feel that captchas in their current form have failed. They're a much bigger obstacle and annoyance to humans than to robots, which renders them useless. My anarchist contribution to this discussion is to demonstrate this absurdity, with a plugin for robots with which **a single line of code is all it takes to bypass reCAPTCHAs on any site**.
 
+> Note: Since `v3.3.0` the plugin will solve [hCaptchas](https://www.hcaptcha.com/) as well, as they've gained significant marketshare through their Cloudflare partnership.
+
 ## Provider
 
 I thought about having the plugin solve captchas directly (e.g. using the [audio challenge](https://github.com/dessant/buster) and speech-to-text APIs), but external solution providers are so cheap and reliable that there is really no benefit in doing that. ¯\\\_(ツ)\_/¯
@@ -160,7 +162,7 @@ _Please note:_ You need a provider configured for this plugin to do it's magic. 
 
 Currently the only builtin solution provider as it's the cheapest and most reliable, from my experience. If you'd like to throw some free captcha credit my way feel free to [signup here](https://2captcha.com?from=6690177) (referral link, allows me to write automated tests against their API).
 
-- Cost: 1000 reCAPTCHAs for 3 USD
+- Cost: 1000 reCAPTCHAs (and hCaptchas) for 3 USD
 - Delay: Solving a reCAPTCHA takes between 10 to 60 seconds
 - Error rate (incorrect solutions): Very rare
 
@@ -172,7 +174,7 @@ You can easily use your own provider as well, by providing the plugin a function
 
 ### How does this work?
 
-- When summoned with `page.solveRecaptchas()` the plugin will attempt to find any visible reCAPTCHAs, extract their configuration, pass that on to the specified solutions provider, take the solutions and put them back into the page (triggering any callback that might be required).
+- When summoned with `page.solveRecaptchas()` the plugin will attempt to find any active reCAPTCHAs & hCaptchas, extract their configuration, pass that on to the specified solutions provider, take the solutions and put them back into the page (triggering any callback that might be required).
 
 ### How do reCAPTCHAs work?
 
@@ -182,15 +184,17 @@ You can easily use your own provider as well, by providing the plugin a function
 
 ### Are ordinary image captchas supported as well?
 
-- No. This plugin focusses on reCAPTCHAs exclusively, with the benefit of being fully automatic. 🔮
+- No. This plugin focusses on reCAPTCHAs and hCaptchas exclusively, with the benefit of being fully automatic. 🔮
 
 ### What about invisible reCAPTCHAs?
 
-- [Invisible reCAPTCHAs](https://developers.google.com/recaptcha/docs/invisible) are a different beast. They're basically used to compute a score of how likely the user is a bot. Based on that score the site owner can block access to resources or (most often) present the user with a reCAPTCHA challenge (which this plugin can solve). The [stealth plugin](https://github.com/berstend/puppeteer-extra/tree/master/packages/puppeteer-extra-plugin-stealth) might be of interest here, as it masks the usage of puppeteer.
+- [Invisible reCAPTCHAs](https://developers.google.com/recaptcha/docs/invisible) are supported. They're basically used to compute a score of how likely the user is a bot. Based on that score the site owner can block access to resources or (most often) present the user with a reCAPTCHA challenge (which this plugin can solve). The [stealth plugin](https://github.com/berstend/puppeteer-extra/tree/master/packages/puppeteer-extra-plugin-stealth) might be of interest here, as it masks the usage of puppeteer.
+- Technically speaking the plugin supports: reCAPTCHA v2, reCAPTCHA v3, invisible reCAPTCHA, hCaptcha, invisible hCaptcha. All of those (multiple as well) are solved when `page.solveRecaptchas()` is called.
 
 ### When should I call `page.solveRecaptchas()`?
 
 - reCAPTCHAs will be solved automatically whenever they **are visible** (_aka their "I'm not a robot" iframe in the DOM_). It's your responsibility to do any required actions to trigger the captcha being shown, if needed.
+  - Note about "invisible" versions of reCAPTCHA/hCaptchas: They don't feature a visible checkbox iframe, the plugin will then solve any open challenge popups instead. :-)
 - If you summon the plugin immediately after navigating to a page it's got your back and will wait automatically until the reCAPTCHA script (if any) has been loaded and initialized.
 - If you call `page.solveRecaptchas()` on a page that has no reCAPTCHAs nothing bad will happen (😄) but the promise will resolve and the rest of your code executes as normal.
 - After solving the reCAPTCHAs the plugin will automatically detect and trigger their [optional callback](https://developers.google.com/recaptcha/docs/display#render_param). This might result in forms being submitted and page navigations to occur, depending on how the site owner implemented the reCAPTCHA.

--- a/packages/puppeteer-extra-plugin-recaptcha/src/content-hcaptcha.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/content-hcaptcha.ts
@@ -1,0 +1,159 @@
+import * as types from './types'
+
+export const ContentScriptDefaultOpts: types.ContentScriptOpts = {
+  visualFeedback: true,
+}
+
+export const ContentScriptDefaultData: types.ContentScriptData = {
+  solutions: [],
+}
+
+/**
+ * Content script for Hcaptcha handling (runs in browser context)
+ * @note External modules are not supported here (due to content script isolation)
+ */
+export class HcaptchaContentScript {
+  private opts: types.ContentScriptOpts
+  private data: types.ContentScriptData
+
+  private baseUrl = 'https://assets.hcaptcha.com/captcha/v1/'
+
+  constructor(
+    opts = ContentScriptDefaultOpts,
+    data = ContentScriptDefaultData
+  ) {
+    this.opts = opts
+    this.data = data
+  }
+
+  private async _waitUntilDocumentReady() {
+    return new Promise(function (resolve) {
+      if (!document || !window) return resolve(null)
+      const loadedAlready = /^loaded|^i|^c/.test(document.readyState)
+      if (loadedAlready) return resolve(null)
+
+      function onReady() {
+        resolve(null)
+        document.removeEventListener('DOMContentLoaded', onReady)
+        window.removeEventListener('load', onReady)
+      }
+
+      document.addEventListener('DOMContentLoaded', onReady)
+      window.addEventListener('load', onReady)
+    })
+  }
+
+  private _paintCaptchaBusy($iframe: HTMLIFrameElement) {
+    try {
+      if (this.opts.visualFeedback) {
+        $iframe.style.filter = `opacity(60%) hue-rotate(400deg)` // violet
+      }
+    } catch (error) {
+      // noop
+    }
+    return $iframe
+  }
+
+  /** Regular checkboxes */
+  private _findRegularCheckboxes() {
+    const nodeList = document.querySelectorAll<HTMLIFrameElement>(
+      `iframe[src^='${this.baseUrl}'][data-hcaptcha-widget-id]:not([src*='invisible'])`
+    )
+    return Array.from(nodeList)
+  }
+
+  /** Find active challenges from invisible hcaptchas */
+  private _findActiveChallenges() {
+    const nodeList = document.querySelectorAll<HTMLIFrameElement>(
+      `div[style*='visible'] iframe[src^='${this.baseUrl}'][src*='hcaptcha-challenge.html'][src*='invisible']`
+    )
+    return Array.from(nodeList)
+  }
+
+  private _extractInfoFromIframes(iframes: HTMLIFrameElement[]) {
+    return iframes
+      .map((el) => el.src.replace('.html#', '.html?'))
+      .map((url) => {
+        const { searchParams } = new URL(url)
+        const result: types.CaptchaInfo = {
+          _vendor: 'hcaptcha',
+          url: document.location.href,
+          id: searchParams.get('id'),
+          sitekey: searchParams.get('sitekey'),
+          display: {
+            size: searchParams.get('size') || 'normal',
+          },
+        }
+        return result
+      })
+  }
+
+  public async findRecaptchas() {
+    const result = {
+      captchas: [] as types.CaptchaInfo[],
+      error: null as null | Error,
+    }
+    try {
+      await this._waitUntilDocumentReady()
+      const iframes = [
+        ...this._findRegularCheckboxes(),
+        ...this._findActiveChallenges(),
+      ]
+      if (!iframes.length) {
+        return result
+      }
+      result.captchas = this._extractInfoFromIframes(iframes)
+      iframes.forEach((el) => {
+        this._paintCaptchaBusy(el)
+      })
+    } catch (error) {
+      result.error = error
+      return result
+    }
+    return result
+  }
+
+  public async enterRecaptchaSolutions() {
+    const result = {
+      solved: [] as types.CaptchaSolved[],
+      error: null as any,
+    }
+    try {
+      await this._waitUntilDocumentReady()
+
+      const solutions = this.data.solutions
+      if (!solutions || !solutions.length) {
+        result.error = 'No solutions provided'
+        return result
+      }
+      result.solved = solutions
+        .filter((solution) => solution._vendor === 'hcaptcha')
+        .filter((solution) => solution.hasSolution === true)
+        .map((solution) => {
+          window.postMessage(
+            JSON.stringify({
+              id: solution.id,
+              label: 'challenge-closed',
+              source: 'hcaptcha',
+              contents: {
+                event: 'challenge-passed',
+                expiration: 120,
+                response: solution.text,
+              },
+            }),
+            '*'
+          )
+          return {
+            _vendor: solution._vendor,
+            id: solution.id,
+            isSolved: true,
+            solvedAt: new Date(),
+          }
+        })
+    } catch (error) {
+      result.error = error
+      return result
+    }
+    return result
+  }
+}

--- a/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
@@ -70,12 +70,16 @@ export class RecaptchaContentScript {
 
   private async _waitUntilDocumentReady() {
     return new Promise(function (resolve) {
-      if (!document || !window) return resolve()
+      if (!document || !window) {
+        return resolve(null)
+      }
       const loadedAlready = /^loaded|^i|^c/.test(document.readyState)
-      if (loadedAlready) return resolve()
+      if (loadedAlready) {
+        return resolve(null)
+      }
 
       function onReady() {
-        resolve()
+        resolve(null)
         document.removeEventListener('DOMContentLoaded', onReady)
         window.removeEventListener('load', onReady)
       }
@@ -228,6 +232,7 @@ export class RecaptchaContentScript {
     if (!client) return
     const info: types.CaptchaInfo = this._pick(['sitekey', 'callback'])(client)
     if (!info.sitekey) return
+    info._vendor = 'recaptcha'
     info.id = client.id
     info.s = client.s // google site specific
     info.widgetId = client.widgetId
@@ -295,6 +300,7 @@ export class RecaptchaContentScript {
         .map((id) => this.getClientById(id))
         .map((client) => {
           const solved: types.CaptchaSolved = {
+            _vendor: 'recaptcha',
             id: client.id,
             responseElement: false,
             responseCallback: false,

--- a/packages/puppeteer-extra-plugin-recaptcha/src/index.test.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/index.test.ts
@@ -9,8 +9,7 @@ import { addExtra } from 'puppeteer-extra'
 
 const PUPPETEER_ARGS = ['--no-sandbox', '--disable-setuid-sandbox']
 
-test('will detect captchas', async (t) => {
-  // const puppeteer = require('puppeteer-extra')
+test('will detect reCAPTCHAs', async (t) => {
   const puppeteer = addExtra(require('puppeteer'))
   const recaptchaPlugin = RecaptchaPlugin()
   puppeteer.use(recaptchaPlugin)
@@ -29,8 +28,35 @@ test('will detect captchas', async (t) => {
   t.is(captchas.length, 1)
 
   const c = captchas[0]
+  t.is(c._vendor, 'recaptcha')
   t.is(c.callback, 'onSuccess')
   t.is(c.hasResponseElement, true)
+  t.is(c.url, url)
+  t.true(c.sitekey && c.sitekey.length > 5)
+
+  await browser.close()
+})
+
+test('will detect hCAPTCHAs', async (t) => {
+  const puppeteer = addExtra(require('puppeteer'))
+  const recaptchaPlugin = RecaptchaPlugin()
+  puppeteer.use(recaptchaPlugin)
+
+  const browser = await puppeteer.launch({
+    args: PUPPETEER_ARGS,
+    headless: true,
+  })
+  const page = await browser.newPage()
+
+  const url = 'https://tinytiger.cf/anything?action=captcha'
+  await page.goto(url, { waitUntil: 'networkidle0' })
+
+  const { captchas, error } = await (page as any).findRecaptchas()
+  t.is(error, null)
+  t.is(captchas.length, 1)
+
+  const c = captchas[0]
+  t.is(c._vendor, 'hcaptcha')
   t.is(c.url, url)
   t.true(c.sitekey && c.sitekey.length > 5)
 

--- a/packages/puppeteer-extra-plugin-recaptcha/src/index.test.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/index.test.ts
@@ -48,7 +48,7 @@ test('will detect hCAPTCHAs', async (t) => {
   })
   const page = await browser.newPage()
 
-  const url = 'https://tinytiger.cf/anything?action=captcha'
+  const url = 'http://democaptcha.com/demo-form-eng/hcaptcha.html'
   await page.goto(url, { waitUntil: 'networkidle0' })
 
   const { captchas, error } = await (page as any).findRecaptchas()

--- a/packages/puppeteer-extra-plugin-recaptcha/src/provider/2captcha-api.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/provider/2captcha-api.ts
@@ -10,7 +10,6 @@ var apiKey
 var apiInUrl = 'http://2captcha.com/in.php'
 var apiResUrl = 'http://2captcha.com/res.php'
 var apiMethod = 'base64'
-var apiMethodRecaptcha = 'userrecaptcha'
 var SOFT_ID = '2589'
 
 var defaultOptions = {
@@ -125,7 +124,7 @@ export const decode = function (base64, options, callback) {
       )
     })
   })
-  request.on('error', function(e){
+  request.on('error', function (e) {
     request.destroy()
     callback(e)
   })
@@ -134,6 +133,7 @@ export const decode = function (base64, options, callback) {
 }
 
 export const decodeReCaptcha = function (
+  captchaMethod,
   captcha,
   pageUrl,
   extraData,
@@ -148,12 +148,18 @@ export const decodeReCaptcha = function (
   httpRequestOptions.method = 'POST'
 
   var postData = {
-    method: apiMethodRecaptcha,
+    method: captchaMethod,
     key: apiKey,
     soft_id: SOFT_ID,
-    googlekey: captcha,
+    // googlekey: captcha,
     pageurl: pageUrl,
     ...extraData,
+  }
+  if (captchaMethod === 'userrecaptcha') {
+    postData.googlekey = captcha
+  }
+  if (captchaMethod === 'hcaptcha') {
+    postData.sitekey = captcha
   }
 
   postData = querystring.stringify(postData)
@@ -188,7 +194,14 @@ export const decodeReCaptcha = function (
           }
           if (this.options.retries > 1) {
             this.options.retries = this.options.retries - 1
-            decode(captcha, this.options, callback)
+            decodeReCaptcha(
+              captchaMethod,
+              captcha,
+              pageUrl,
+              extraData,
+              this.options,
+              callback
+            )
           } else {
             callbackToInitialCallback('CAPTCHA_FAILED_TOO_MANY_TIMES')
           }
@@ -197,7 +210,7 @@ export const decodeReCaptcha = function (
       )
     })
   })
-  request.on('error', function(e){
+  request.on('error', function (e) {
     request.destroy()
     callback(e)
   })
@@ -227,7 +240,7 @@ export const decodeUrl = function (uri, options, callback) {
       decode(body, options, callback)
     })
   })
-  request.on('error', function(e){
+  request.on('error', function (e) {
     request.destroy()
     callback(e)
   })

--- a/packages/puppeteer-extra-plugin-recaptcha/src/provider/2captcha.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/provider/2captcha.ts
@@ -18,6 +18,7 @@ export interface DecodeRecaptchaAsyncResult {
 
 async function decodeRecaptchaAsync(
   token: string,
+  vendor: types.CaptchaVendor,
   sitekey: string,
   url: string,
   extraData: any,
@@ -28,7 +29,12 @@ async function decodeRecaptchaAsync(
       resolve({ err, result, invalid })
     try {
       solver.setApiKey(token)
-      solver.decodeReCaptcha(sitekey, url, extraData, opts, cb)
+
+      let method = 'userrecaptcha'
+      if (vendor === 'hcaptcha') {
+        method = 'hcaptcha'
+      }
+      solver.decodeReCaptcha(method, sitekey, url, extraData, opts, cb)
     } catch (error) {
       return resolve({ err: error })
     }
@@ -50,6 +56,7 @@ async function getSolution(
   token: string
 ): Promise<types.CaptchaSolution> {
   const solution: types.CaptchaSolution = {
+    _vendor: captcha._vendor,
     provider: PROVIDER_ID,
   }
   try {
@@ -65,6 +72,7 @@ async function getSolution(
     }
     const { err, result, invalid } = await decodeRecaptchaAsync(
       token,
+      captcha._vendor,
       captcha.sitekey,
       captcha.url,
       extraData

--- a/packages/puppeteer-extra-plugin-recaptcha/src/solve.test.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/solve.test.ts
@@ -1,0 +1,84 @@
+import test from 'ava'
+
+import RecaptchaPlugin from './index'
+
+import { addExtra } from 'puppeteer-extra'
+
+const PUPPETEER_ARGS = ['--no-sandbox', '--disable-setuid-sandbox']
+
+test('will solve reCAPTCHAs', async (t) => {
+  if (!process.env.TWOCAPTCHA_TOKEN) {
+    t.truthy('foo')
+    console.log('TWOCAPTCHA_TOKEN not set, skipping test.')
+    return
+  }
+
+  const puppeteer = addExtra(require('puppeteer'))
+  const recaptchaPlugin = RecaptchaPlugin({
+    provider: {
+      id: '2captcha',
+      token: process.env.TWOCAPTCHA_TOKEN,
+    },
+  })
+  puppeteer.use(recaptchaPlugin)
+
+  const browser = await puppeteer.launch({
+    args: PUPPETEER_ARGS,
+    headless: true,
+  })
+  const page = await browser.newPage()
+
+  const url = 'https://www.google.com/recaptcha/api2/demo'
+  await page.goto(url, { waitUntil: 'networkidle0' })
+
+  const result = await (page as any).solveRecaptchas()
+
+  const { captchas, solutions, solved, error } = result
+  t.falsy(error)
+
+  t.is(captchas.length, 1)
+  t.is(solutions.length, 1)
+  t.is(solved.length, 1)
+  t.is(solved[0]._vendor, 'recaptcha')
+  t.is(solved[0].isSolved, true)
+
+  await browser.close()
+})
+
+test('will solve hCAPTCHAs', async (t) => {
+  if (!process.env.TWOCAPTCHA_TOKEN) {
+    t.truthy('foo')
+    console.log('TWOCAPTCHA_TOKEN not set, skipping test.')
+    return
+  }
+
+  const puppeteer = addExtra(require('puppeteer'))
+  const recaptchaPlugin = RecaptchaPlugin({
+    provider: {
+      id: '2captcha',
+      token: process.env.TWOCAPTCHA_TOKEN,
+    },
+  })
+  puppeteer.use(recaptchaPlugin)
+
+  const browser = await puppeteer.launch({
+    args: PUPPETEER_ARGS,
+    headless: true,
+  })
+  const page = await browser.newPage()
+
+  const url = 'http://democaptcha.com/demo-form-eng/hcaptcha.html'
+  await page.goto(url, { waitUntil: 'networkidle0' })
+
+  const result = await (page as any).solveRecaptchas()
+  const { captchas, solutions, solved, error } = result
+  t.falsy(error)
+
+  t.is(captchas.length, 1)
+  t.is(solutions.length, 1)
+  t.is(solved.length, 1)
+  t.is(solved[0]._vendor, 'hcaptcha')
+  t.is(solved[0].isSolved, true)
+
+  await browser.close()
+})

--- a/packages/puppeteer-extra-plugin-recaptcha/src/types.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/types.ts
@@ -53,7 +53,10 @@ export type SolveRecaptchasResult = FindRecaptchasResult &
   EnterRecaptchaSolutionsResult &
   GetSolutionsResult
 
+export type CaptchaVendor = 'recaptcha' | 'hcaptcha'
+
 export interface CaptchaInfo {
+  _vendor: CaptchaVendor
   id?: string // captcha id
   widgetId?: number
   sitekey?: string
@@ -72,6 +75,7 @@ export interface CaptchaInfo {
 }
 
 export interface CaptchaSolution {
+  _vendor: CaptchaVendor
   id?: string // captcha id
   provider?: string
   providerCaptchaId?: string
@@ -84,6 +88,7 @@ export interface CaptchaSolution {
 }
 
 export interface CaptchaSolved {
+  _vendor: CaptchaVendor
   id?: string // captcha id
   responseElement?: boolean
   responseCallback?: boolean


### PR DESCRIPTION
I opted to re-use the same plugin name and APIs for convenience 😄 The term "reCAPTCHA" is now used in the same way `youtube-dl` supports much more than just youtube.

`page.solveRecaptchas()` will now solve any number and combination of: reCAPTCHA v2, reCAPTCHA v3, invisible reCAPTCHA, hCaptcha, invisible hCaptcha

Fixes #177

![image](https://user-images.githubusercontent.com/1368633/100382890-9c093a00-301c-11eb-8d39-eee1854e5530.png)
