### PR TITLE
feat(plugin-recaptcha): Add support for reCAPTCHA Enterprise Add reCAPTCHA Enterprise support

### DIFF
--- a/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
@@ -115,6 +115,8 @@ export class RecaptchaContentScript {
     return Array.from(
       document.querySelectorAll<HTMLIFrameElement>(
         `iframe[src^='https://www.google.com/recaptcha/api2/anchor'][name^="a-"]`
+        + ', ' +
+        `iframe[src^='https://www.google.com/recaptcha/enterprise/anchor'][name^="a-"]`
       )
     )
   }
@@ -123,12 +125,20 @@ export class RecaptchaContentScript {
       `iframe[src^='https://www.google.com/recaptcha/api2/anchor'][name^="a-${
         id || ''
       }"]`
+      + ', ' +
+      `iframe[src^='https://www.google.com/recaptcha/enterprise/anchor'][name^="a-${
+        id || ''
+      }"]`
     )
   }
 
   private _hideChallengeWindowIfPresent(id?: string) {
     let frame: HTMLElement | null = document.querySelector<HTMLIFrameElement>(
       `iframe[src^='https://www.google.com/recaptcha/api2/bframe'][name^="c-${
+        id || ''
+      }"]`
+      + ', ' +
+      `iframe[src^='https://www.google.com/recaptcha/enterprise/bframe'][name^="c-${
         id || ''
       }"]`
     )
@@ -183,6 +193,10 @@ export class RecaptchaContentScript {
         (id) =>
           document.querySelectorAll(
             `iframe[src^='https://www.google.com/recaptcha/api2/bframe'][name^="c-${
+              id || ''
+            }"]`
+            + ', ' +
+            `iframe[src^='https://www.google.com/recaptcha/enterprise/bframe'][name^="c-${
               id || ''
             }"]`
           ).length


### PR DESCRIPTION
Hi,

Thanks for maintain library.
While using puppeteer-extra-plugin-recaptcha, I found another set of urls for reCAPTCHA enterprise.

I added urls to recaptcha find method.

If you can, could you merge that?
I don't know enough your community rules, tell me what should I do if wrong.

thanks.
