### PR TITLE
fix(plugin-user-data-dir): Prevent ENOTEMPTY error

### DIFF
--- a/packages/puppeteer-extra-plugin-user-data-dir/index.js
+++ b/packages/puppeteer-extra-plugin-user-data-dir/index.js
@@ -69,7 +69,7 @@ class Plugin extends PuppeteerExtraPlugin {
     try {
       // We're doing it sync to improve chances to cleanup
       // correctly in the event of ultimate disaster.
-      fse.removeSync(this._userDataDir)
+      fse.rmdirSync(this._userDataDir, { recursive: true })
     } catch (e) {
       debug(e)
     }


### PR DESCRIPTION
Without the change, `fse.removeSync` only works with empty folder, so fails with ENOTEMPTY - https://github.com/jprichardson/node-fs-extra/issues/178