### PR TITLE
fix(plugin-stealth): Improve navigator patching

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/_utils/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/_utils/index.test.js
@@ -16,6 +16,7 @@ test('splitObjPath: will do what it says', async t => {
 })
 
 test('makeNativeString: will do what it says', async t => {
+  utils.init()
   t.is(utils.makeNativeString('bob'), 'function bob() { [native code] }')
   t.is(
     utils.makeNativeString('toString'),
@@ -223,21 +224,22 @@ function toStringTest(obj) {
 - Function.prototype.toString.call(obj): ${Function.prototype.toString.call(
     obj
   )}
-- Function.prototype.valueOf.call(obj) + "": ${Function.prototype.valueOf.call(
-    obj
-  ) + ''}
-- obj.toString === Function.prototype.toString: ${obj.toString ===
-    Function.prototype.toString}
+- Function.prototype.valueOf.call(obj) + "": ${
+    Function.prototype.valueOf.call(obj) + ''
+  }
+- obj.toString === Function.prototype.toString: ${
+    obj.toString === Function.prototype.toString
+  }
 `.trim()
 }
 
 test('patchToString: passes all toString tests', async t => {
-  const toStringVanilla = await (async function() {
+  const toStringVanilla = await (async function () {
     const browser = await vanillaPuppeteer.launch({ headless: true })
     const page = await browser.newPage()
     return page.evaluate(toStringTest, 'HTMLMediaElement.prototype.canPlayType')
   })()
-  const toStringStealth = await (async function() {
+  const toStringStealth = await (async function () {
     const browser = await vanillaPuppeteer.launch({ headless: true })
     const page = await browser.newPage()
     await withUtils(page).evaluate(utils => {

--- a/packages/puppeteer-extra-plugin-stealth/evasions/_utils/withUtils.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/_utils/withUtils.js
@@ -9,14 +9,14 @@ module.exports = page => ({
   /**
    * Simple `page.evaluate` replacement to preload utils
    */
-  evaluate: async function(mainFunction, ...args) {
+  evaluate: async function (mainFunction, ...args) {
     return page.evaluate(
       ({ _utilsFns, _mainFunction, _args }) => {
         // Add this point we cannot use our utililty functions as they're just strings, we need to materialize them first
         const utils = Object.fromEntries(
           Object.entries(_utilsFns).map(([key, value]) => [key, eval(value)]) // eslint-disable-line no-eval
         )
-        utils.preloadCache()
+        utils.init()
         return eval(_mainFunction)(utils, ..._args) // eslint-disable-line no-eval
       },
       {
@@ -29,14 +29,14 @@ module.exports = page => ({
   /**
    * Simple `page.evaluateOnNewDocument` replacement to preload utils
    */
-  evaluateOnNewDocument: async function(mainFunction, ...args) {
+  evaluateOnNewDocument: async function (mainFunction, ...args) {
     return page.evaluateOnNewDocument(
       ({ _utilsFns, _mainFunction, _args }) => {
         // Add this point we cannot use our utililty functions as they're just strings, we need to materialize them first
         const utils = Object.fromEntries(
           Object.entries(_utilsFns).map(([key, value]) => [key, eval(value)]) // eslint-disable-line no-eval
         )
-        utils.preloadCache()
+        utils.init()
         return eval(_mainFunction)(utils, ..._args) // eslint-disable-line no-eval
       },
       {

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.hardwareConcurrency/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.hardwareConcurrency/index.test.js
@@ -1,6 +1,8 @@
 const test = require('ava')
 const os = require('os')
 
+const { vanillaPuppeteer, addExtra } = require('../../test/util')
+
 const {
   getVanillaFingerPrint,
   getStealthFingerPrint
@@ -9,19 +11,49 @@ const Plugin = require('.')
 
 const fingerprintFn = page => page.evaluate('navigator.hardwareConcurrency')
 
-test('vanilla: navigator.hardwareConcurrency matches real core count', async t => {
+test('vanilla: matches real core count', async t => {
   const { pageFnResult } = await getVanillaFingerPrint(fingerprintFn)
   t.is(pageFnResult, os.cpus().length)
 })
 
-test('stealth: navigator.hardwareConcurrency is set to 4', async t => {
+test('stealth: default is set to 4', async t => {
   const { pageFnResult } = await getStealthFingerPrint(Plugin, fingerprintFn)
   t.is(pageFnResult, 4)
 })
 
-test('stealth: navigator.hardwareConcurrency customized value', async t => {
+test('stealth: will override value correctly', async t => {
   const { pageFnResult } = await getStealthFingerPrint(Plugin, fingerprintFn, {
     hardwareConcurrency: 8
   })
   t.is(pageFnResult, 8)
+})
+
+test('stealth: does patch getters properly', async t => {
+  const puppeteer = addExtra(vanillaPuppeteer).use(Plugin())
+  const browser = await puppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+
+  const results = await page.evaluate(() => {
+    const hasInvocationError = (() => {
+      try {
+        // eslint-disable-next-line dot-notation
+        Object['seal'](Object.getPrototypeOf(navigator)['hardwareConcurrency'])
+        return false
+      } catch (err) {
+        return true
+      }
+    })()
+    return {
+      hasInvocationError,
+      toString: Object.getOwnPropertyDescriptor(
+        Object.getPrototypeOf(navigator),
+        'hardwareConcurrency'
+      ).get.toString()
+    }
+  })
+
+  t.deepEqual(results, {
+    hasInvocationError: true,
+    toString: 'function get hardwareConcurrency() { [native code] }'
+  })
 })

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.languages/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.languages/index.test.js
@@ -59,3 +59,44 @@ test('stealth: will not leak modifications', async t => {
   )
   t.deepEqual(test2, [])
 })
+
+test('stealth: does patch getters properly', async t => {
+  const puppeteer = addExtra(vanillaPuppeteer).use(Plugin())
+  const browser = await puppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+
+  const results = await page.evaluate(() => {
+    const hasInvocationError = (() => {
+      try {
+        // eslint-disable-next-line dot-notation
+        Object['seal'](Object.getPrototypeOf(navigator)['languages'])
+        return false
+      } catch (err) {
+        return true
+      }
+    })()
+    const hasPushError = (() => {
+      try {
+        // eslint-disable-next-line dot-notation
+        navigator.languages.push(null)
+        return false
+      } catch (err) {
+        return true
+      }
+    })()
+    return {
+      hasInvocationError,
+      hasPushError,
+      toString: Object.getOwnPropertyDescriptor(
+        Object.getPrototypeOf(navigator),
+        'languages'
+      ).get.toString()
+    }
+  })
+
+  t.deepEqual(results, {
+    hasInvocationError: true,
+    hasPushError: true,
+    toString: 'function get languages() { [native code] }'
+  })
+})

--- a/packages/puppeteer-extra-plugin-stealth/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint --ext .js .",
     "test:js": "ava --concurrency 2 -v",
     "test": "run-p test:js lint",
-    "test-ci": "run-s test",
+    "test-ci": "run-s test:js",
     "types": "npx --package typescript@3.7 tsc --emitDeclarationOnly --declaration --allowJs index.js"
   },
   "engines": {


### PR DESCRIPTION
This PR:
- Hardens a couple of navigator evasions (`navigator.vendor`, `navigator.languages`, `navigator.hardwareConcurrency`) and patches leaks, with additional tests
- Adds re-usable stealth utilities for getter patching
- Cleans up stealth utilities a bit (e.g. we run `preloadCache` only once now)
- Fixes `Function.prototype.toString` error stack trace leaks

## Improved spoofing

![image](https://user-images.githubusercontent.com/1368633/105749133-4df0b400-5f43-11eb-8758-807bf60edfee.png)

