### PR TITLE
feat(plugin-stealth): Add support for UA hints

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
@@ -115,7 +115,7 @@ class Plugin extends PuppeteerExtraPlugin {
     // Return OS version
     const _getPlatformVersion = () => {
       if (ua.includes('Mac OS X')) {
-        return ua.match(/Mac OS X ([^_]+)/)[1]
+        return ua.match(/Mac OS X ([^)]+)/)[1]
       } else if (ua.includes('Android')) {
         return ua.match(/Android ([^;]+)/)[1]
       } else if (ua.includes('Windows')) {
@@ -130,7 +130,7 @@ class Plugin extends PuppeteerExtraPlugin {
 
     // Return the Android model, empty on desktop
     const _getPlatformModel = () =>
-      _getMobile() ? ua.match(/Android.*?;.*?\/([^;]+)/)[1] : ''
+      _getMobile() ? ua.match(/Android.*?;\s([^)]+)/)[1] : ''
 
     const _getMobile = () => ua.includes('Android')
 

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
@@ -35,7 +35,6 @@ const { PuppeteerExtraPlugin } = require('puppeteer-extra-plugin')
  * @param {Object} [opts] - Options
  * @param {string} [opts.userAgent] - The user agent to use (default: browser.userAgent())
  * @param {string} [opts.locale] - The locale to use in `Accept-Language` header and in `navigator.languages` (default: `en-US,en;q=0.9`)
- * @param {string} [opts.platform] - The platform to use in `navigator.platform` (default: `Win32`)
  *
  */
 class Plugin extends PuppeteerExtraPlugin {
@@ -50,21 +49,104 @@ class Plugin extends PuppeteerExtraPlugin {
   get defaults() {
     return {
       userAgent: null,
-      locale: 'en-US,en',
-      platform: 'Win32'
+      locale: 'en-US,en'
     }
   }
 
   async onPageCreated(page) {
+    // Determine the full user agent string, strip the "Headless" part
+    const ua =
+      this.opts.userAgent ||
+      (await page.browser().userAgent()).replace('HeadlessChrome/', 'Chrome/')
+
+    // Full version number from Chrome
+    const uaVersion = ua.includes('Chrome/')
+      ? ua.match(/Chrome\/([^\s]+)/)[1]
+      : (await page.browser().version()).match(/\/([^\s]+)/)[1]
+
+    // Get platform identifier (short or long version)
+    const _getPlatform = (extended = false) => {
+      if (ua.includes('Mac OS X')) {
+        return extended ? 'Mac OS X' : 'MacIntel'
+      } else if (ua.includes('Android')) {
+        return 'Android'
+      } else if (ua.includes('Linux')) {
+        return 'Linux'
+      } else {
+        return extended ? 'Windows' : 'Win32'
+      }
+    }
+
+    // Source in C++: https://source.chromium.org/chromium/chromium/src/+/master:chrome/browser/chrome_content_browser_client.cc;l=1187-1238
+    const _getBrands = () => {
+      const seed = uaVersion.split('.')[0] // the major version number of Chrome
+
+      const order = [
+        [0, 1, 2],
+        [0, 2, 1],
+        [1, 0, 2],
+        [1, 2, 0],
+        [2, 0, 1],
+        [2, 1, 0]
+      ][seed % 6]
+      const escapedChars = [' ', ' ', ';']
+
+      const greaseyBrand = `${escapedChars[order[0]]}Not${
+        escapedChars[order[1]]
+      }A${escapedChars[order[2]]}Brand`
+
+      const greasedBrandVersionList = []
+      greasedBrandVersionList[order[0]] = {
+        brand: greaseyBrand,
+        version: '99'
+      }
+      greasedBrandVersionList[order[1]] = {
+        brand: 'Chromium',
+        version: seed
+      }
+      greasedBrandVersionList[order[2]] = {
+        brand: 'Google Chrome',
+        version: seed
+      }
+
+      return greasedBrandVersionList
+    }
+
+    // Return OS version
+    const _getPlatformVersion = () => {
+      if (ua.includes('Mac OS X')) {
+        return ua.match(/Mac OS X ([^_]+)/)[1]
+      } else if (ua.includes('Android')) {
+        return ua.match(/Android ([^;]+)/)[1]
+      } else if (ua.includes('Windows')) {
+        return ua.match(/([\d|.]+);/)[1]
+      } else {
+        return ''
+      }
+    }
+
+    // Get architecture, this seems to be empty on mobile and x86 on desktop
+    const _getPlatformArch = () => (_getMobile() ? '' : 'x86')
+
+    // Return the Android model, empty on desktop
+    const _getPlatformModel = () =>
+      _getMobile() ? ua.match(/Android.*?;.*?\/([^;]+)/)[1] : ''
+
+    const _getMobile = () => ua.includes('Android')
+
     const override = {
-      userAgent:
-        this.opts.userAgent ||
-        (await page.browser().userAgent()).replace(
-          'HeadlessChrome/',
-          'Chrome/'
-        ),
+      userAgent: ua,
       acceptLanguage: this.opts.locale || 'en-US,en',
-      platform: this.opts.platform || 'Win32'
+      platform: _getPlatform(),
+      userAgentMetadata: {
+        brands: _getBrands(),
+        fullVersion: uaVersion,
+        platform: _getPlatform(true),
+        platformVersion: _getPlatformVersion(),
+        architecture: _getPlatformArch(),
+        model: _getPlatformModel(),
+        mobile: _getMobile()
+      }
     }
 
     this.debug('onPageCreated - Will set these user agent options', {

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
@@ -3,10 +3,10 @@
 const { PuppeteerExtraPlugin } = require('puppeteer-extra-plugin')
 
 /**
- * Fixes the UserAgent info (composed of UA string, Accept-Language, Platform).
+ * Fixes the UserAgent info (composed of UA string, Accept-Language, Platform, and UA hints).
  *
  * If you don't provide any values this plugin will default to using the regular UserAgent string (while stripping the headless part).
- * Default language is set to "en-US,en", default platform is "win32".
+ * Default language is set to "en-US,en", the other settings match the UserAgent string.
  *
  * By default puppeteer will not set a `Accept-Language` header in headless:
  * It's (theoretically) possible to fix that using either `page.setExtraHTTPHeaders` or a `--lang` launch arg.
@@ -28,13 +28,13 @@ const { PuppeteerExtraPlugin } = require('puppeteer-extra-plugin')
  *
  * // Stealth plugins are just regular `puppeteer-extra` plugins and can be added as such
  * const UserAgentOverride = require("puppeteer-extra-plugin-stealth/evasions/user-agent-override")
- * // Define custom UA, locale and platform
- * const ua = UserAgentOverride({ userAgent: "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)", locale: "de-DE,de;q=0.9", platform: "Win32" })
+ * // Define custom UA and locale
+ * const ua = UserAgentOverride({ userAgent: "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)", locale: "de-DE,de" })
  * puppeteer.use(ua)
  *
  * @param {Object} [opts] - Options
  * @param {string} [opts.userAgent] - The user agent to use (default: browser.userAgent())
- * @param {string} [opts.locale] - The locale to use in `Accept-Language` header and in `navigator.languages` (default: `en-US,en;q=0.9`)
+ * @param {string} [opts.locale] - The locale to use in `Accept-Language` header and in `navigator.languages` (default: `en-US,en`)
  *
  */
 class Plugin extends PuppeteerExtraPlugin {

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
@@ -174,6 +174,11 @@ class Plugin extends PuppeteerExtraPlugin {
     this._headless = options.headless
   }
 
+  async beforeConnect() {
+    // Treat browsers using connect() as headless browsers
+    this._headless = true
+  }
+
   get data() {
     return [
       {

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.test.js
@@ -120,22 +120,42 @@ test('stealth: navigator.languages with custom locale', async t => {
   t.deepEqual(lang, 'de-DE')
 })
 
-test('stealth: navigator.platform with default platform', async t => {
-  const puppeteer = addExtra(vanillaPuppeteer).use(Plugin())
-  const browser = await puppeteer.launch({ headless: true })
-  const page = await browser.newPage()
-
-  const platform = await page.evaluate(() => navigator.platform)
-  t.true(platform === 'Win32')
-})
-
-test('stealth: navigator.platform with custom platform', async t => {
+test('stealth: test if UA hints are correctly set', async t => {
   const puppeteer = addExtra(vanillaPuppeteer).use(
-    Plugin({ platform: 'MyFunkyPlatform' })
+    Plugin({
+      userAgent:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'
+    })
   )
-  const browser = await puppeteer.launch({ headless: true })
+
+  const browser = await puppeteer.launch({
+    headless: false, // only works on headful
+    args: ['--enable-features=UserAgentClientHint']
+  })
+
+  const majorVersion = parseInt(
+    (await browser.version()).match(/\/([^\.]+)/)[1]
+  )
+  if (majorVersion < 88) {
+    return t.true(true) // Skip test on browsers that don't support UA hints
+  }
+
   const page = await browser.newPage()
 
-  const platform = await page.evaluate(() => navigator.platform)
-  t.true(platform === 'MyFunkyPlatform')
+  await page.goto('https://headers.cf/headers/?format=raw')
+  const firstLoad = await page.content()
+  t.true(
+    firstLoad.includes(
+      `sec-ch-ua: "Chromium";v="88", "Google Chrome";v="88", ";Not A Brand";v="99"`
+    )
+  )
+
+  await page.reload()
+  const secondLoad = await page.content()
+  t.true(secondLoad.includes('sec-ch-ua-mobile: ?0'))
+  t.true(secondLoad.includes('sec-ch-ua-full-version: "88.0.4324.96"'))
+  t.true(secondLoad.includes('sec-ch-ua-arch: "x86"'))
+  t.true(secondLoad.includes('sec-ch-ua-platform: "Windows"'))
+  t.true(secondLoad.includes('sec-ch-ua-platform-version: "10.0"'))
+  t.true(secondLoad.includes('sec-ch-ua-model: ""'))
 })

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.test.js
@@ -120,8 +120,10 @@ test('stealth: navigator.languages with custom locale', async t => {
   t.deepEqual(lang, 'de-DE')
 })
 
-const _testUAHint = async userAgent => {
-  const puppeteer = addExtra(vanillaPuppeteer).use(Plugin({ userAgent }))
+const _testUAHint = async (userAgent, locale) => {
+  const puppeteer = addExtra(vanillaPuppeteer).use(
+    Plugin({ userAgent, locale })
+  )
 
   const browser = await puppeteer.launch({
     headless: false, // only works on headful
@@ -144,7 +146,8 @@ const _testUAHint = async userAgent => {
 
 test('stealth: test if UA hints are correctly set - Windows 10', async t => {
   const page = await _testUAHint(
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.9999.99 Safari/537.36'
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.9999.99 Safari/537.36',
+    'en-AU'
   )
   if (!page) {
     t.true(true) // skip
@@ -156,6 +159,7 @@ test('stealth: test if UA hints are correctly set - Windows 10', async t => {
       `sec-ch-ua: "Google Chrome";v="99", " Not;A Brand";v="99", "Chromium";v="99"`
     )
   )
+  t.true(firstLoad.includes(`Accept-Language: en-AU`))
 
   await page.reload()
   const secondLoad = await page.content()
@@ -169,7 +173,8 @@ test('stealth: test if UA hints are correctly set - Windows 10', async t => {
 
 test('stealth: test if UA hints are correctly set - macOS 11', async t => {
   const page = await _testUAHint(
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.9999.99 Safari/537.36'
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.9999.99 Safari/537.36',
+    'de-DE'
   )
   if (!page) {
     t.true(true) // skip
@@ -181,6 +186,7 @@ test('stealth: test if UA hints are correctly set - macOS 11', async t => {
       `sec-ch-ua: "Google Chrome";v="99", " Not;A Brand";v="99", "Chromium";v="99"`
     )
   )
+  t.true(firstLoad.includes(`Accept-Language: de-DE`))
 
   await page.reload()
   const secondLoad = await page.content()
@@ -194,7 +200,8 @@ test('stealth: test if UA hints are correctly set - macOS 11', async t => {
 
 test('stealth: test if UA hints are correctly set - Android 10', async t => {
   const page = await _testUAHint(
-    'Mozilla/5.0 (Linux; Android 10; SM-P205) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.9999.99 Safari/537.36'
+    'Mozilla/5.0 (Linux; Android 10; SM-P205) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.9999.99 Safari/537.36',
+    'nl-NL'
   )
   if (!page) {
     t.true(true) // skip
@@ -206,6 +213,7 @@ test('stealth: test if UA hints are correctly set - Android 10', async t => {
       `sec-ch-ua: "Google Chrome";v="99", " Not;A Brand";v="99", "Chromium";v="99"`
     )
   )
+  t.true(firstLoad.includes(`Accept-Language: nl-NL`))
 
   await page.reload()
   const secondLoad = await page.content()

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.test.js
@@ -125,9 +125,7 @@ const _testUAHint = async userAgent => {
 
   const browser = await puppeteer.launch({
     headless: false, // only works on headful
-    args: ['--enable-features=UserAgentClientHint'],
-    executablePath:
-      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+    args: ['--enable-features=UserAgentClientHint']
   })
 
   const majorVersion = parseInt(

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.test.js
@@ -120,6 +120,35 @@ test('stealth: navigator.languages with custom locale', async t => {
   t.deepEqual(lang, 'de-DE')
 })
 
+test('stealth: navigator.platform with maskLinux true (default)', async t => {
+  const puppeteer = addExtra(vanillaPuppeteer).use(
+    Plugin({
+      userAgent:
+        'Mozilla/5.0 (X11; Ubuntu; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.9.9999.99 Safari/537.36'
+    })
+  )
+  const browser = await puppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+
+  const platform = await page.evaluate(() => navigator.platform)
+  t.true(platform === 'Win32')
+})
+
+test('stealth: navigator.platform with maskLinux false', async t => {
+  const puppeteer = addExtra(vanillaPuppeteer).use(
+    Plugin({
+      userAgent:
+        'Mozilla/5.0 (X11; Ubuntu; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.9.9999.99 Safari/537.36',
+      maskLinux: false
+    })
+  )
+  const browser = await puppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+
+  const platform = await page.evaluate(() => navigator.platform)
+  t.true(platform === 'Linux')
+})
+
 const _testUAHint = async (userAgent, locale) => {
   const puppeteer = addExtra(vanillaPuppeteer).use(
     Plugin({ userAgent, locale })

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/readme.md
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/readme.md
@@ -6,11 +6,12 @@
 
 - [class: Plugin](#class-plugin)
 
-### class: [Plugin](https://github.com/berstend/puppeteer-extra/blob/12a76f2678ba8d3e8bd665da94a59aed500e510a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js#L40-L159)
+### class: [Plugin](https://github.com/berstend/puppeteer-extra/blob/ab0047d1af7dc38412744abdb61bcfc35c42dc34/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js#L42-L203)
 
 - `opts` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Options (optional, default `{}`)
   - `opts.userAgent` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** The user agent to use (default: browser.userAgent())
   - `opts.locale` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** The locale to use in `Accept-Language` header and in `navigator.languages` (default: `en-US,en`)
+  - `opts.maskLinux` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** Wether to hide Linux as platform in the user agent or not - true by default
 
 **Extends: PuppeteerExtraPlugin**
 
@@ -18,6 +19,7 @@ Fixes the UserAgent info (composed of UA string, Accept-Language, Platform, and 
 
 If you don't provide any values this plugin will default to using the regular UserAgent string (while stripping the headless part).
 Default language is set to "en-US,en", the other settings match the UserAgent string.
+If you are running on Linux, it will mask the settins to look like Windows. This behavior can be disabled with the `maskLinux` option.
 
 By default puppeteer will not set a `Accept-Language` header in headless:
 It's (theoretically) possible to fix that using either `page.setExtraHTTPHeaders` or a `--lang` launch arg.

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/readme.md
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/readme.md
@@ -4,21 +4,20 @@
 
 #### Table of Contents
 
-- [class: Plugin](#class-plugin)
+-   [class: Plugin](#class-plugin)
 
-### class: [Plugin](https://github.com/berstend/puppeteer-extra/blob/e6133619b051febed630ada35241664eba59b9fa/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js#L41-L77)
+### class: [Plugin](https://github.com/berstend/puppeteer-extra/blob/f96d8b0cedfe93b2867fcdd2049364a242bdc036/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js#L40-L159)
 
-- `opts` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Options (optional, default `{}`)
-  - `opts.userAgent` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** The user agent to use (default: browser.userAgent())
-  - `opts.locale` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** The locale to use in `Accept-Language` header and in `navigator.languages` (default: `en-US,en;q=0.9`)
-  - `opts.platform` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** The platform to use in `navigator.platform` (default: `Win32`)
+-   `opts` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Options (optional, default `{}`)
+    -   `opts.userAgent` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** The user agent to use (default: browser.userAgent())
+    -   `opts.locale` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** The locale to use in `Accept-Language` header and in `navigator.languages` (default: `en-US,en`)
 
 **Extends: PuppeteerExtraPlugin**
 
-Fixes the UserAgent info (composed of UA string, Accept-Language, Platform).
+Fixes the UserAgent info (composed of UA string, Accept-Language, Platform, and UA hints).
 
 If you don't provide any values this plugin will default to using the regular UserAgent string (while stripping the headless part).
-Default language is set to "en-US,en", default platform is "win32".
+Default language is set to "en-US,en", the other settings match the UserAgent string.
 
 By default puppeteer will not set a `Accept-Language` header in headless:
 It's (theoretically) possible to fix that using either `page.setExtraHTTPHeaders` or a `--lang` launch arg.
@@ -32,23 +31,19 @@ as it will reset the language and platform values you set with this plugin.
 Example:
 
 ```javascript
-const puppeteer = require('puppeteer-extra')
+const puppeteer = require("puppeteer-extra")
 
-const StealthPlugin = require('puppeteer-extra-plugin-stealth')
+const StealthPlugin = require("puppeteer-extra-plugin-stealth")
 const stealth = StealthPlugin()
 // Remove this specific stealth plugin from the default set
-stealth.enabledEvasions.delete('user-agent-override')
+stealth.enabledEvasions.delete("user-agent-override")
 puppeteer.use(stealth)
 
 // Stealth plugins are just regular `puppeteer-extra` plugins and can be added as such
-const UserAgentOverride = require('puppeteer-extra-plugin-stealth/evasions/user-agent-override')
-// Define custom UA, locale and platform
-const ua = UserAgentOverride({
-  userAgent: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)',
-  locale: 'de-DE,de;q=0.9',
-  platform: 'Win32'
-})
+const UserAgentOverride = require("puppeteer-extra-plugin-stealth/evasions/user-agent-override")
+// Define custom UA and locale
+const ua = UserAgentOverride({ userAgent: "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)", locale: "de-DE,de" })
 puppeteer.use(ua)
 ```
 
----
+* * *

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/readme.md
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/readme.md
@@ -4,13 +4,13 @@
 
 #### Table of Contents
 
--   [class: Plugin](#class-plugin)
+- [class: Plugin](#class-plugin)
 
-### class: [Plugin](https://github.com/berstend/puppeteer-extra/blob/f96d8b0cedfe93b2867fcdd2049364a242bdc036/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js#L40-L159)
+### class: [Plugin](https://github.com/berstend/puppeteer-extra/blob/12a76f2678ba8d3e8bd665da94a59aed500e510a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js#L40-L159)
 
--   `opts` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Options (optional, default `{}`)
-    -   `opts.userAgent` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** The user agent to use (default: browser.userAgent())
-    -   `opts.locale` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** The locale to use in `Accept-Language` header and in `navigator.languages` (default: `en-US,en`)
+- `opts` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Options (optional, default `{}`)
+  - `opts.userAgent` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** The user agent to use (default: browser.userAgent())
+  - `opts.locale` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** The locale to use in `Accept-Language` header and in `navigator.languages` (default: `en-US,en`)
 
 **Extends: PuppeteerExtraPlugin**
 
@@ -31,19 +31,22 @@ as it will reset the language and platform values you set with this plugin.
 Example:
 
 ```javascript
-const puppeteer = require("puppeteer-extra")
+const puppeteer = require('puppeteer-extra')
 
-const StealthPlugin = require("puppeteer-extra-plugin-stealth")
+const StealthPlugin = require('puppeteer-extra-plugin-stealth')
 const stealth = StealthPlugin()
 // Remove this specific stealth plugin from the default set
-stealth.enabledEvasions.delete("user-agent-override")
+stealth.enabledEvasions.delete('user-agent-override')
 puppeteer.use(stealth)
 
 // Stealth plugins are just regular `puppeteer-extra` plugins and can be added as such
-const UserAgentOverride = require("puppeteer-extra-plugin-stealth/evasions/user-agent-override")
+const UserAgentOverride = require('puppeteer-extra-plugin-stealth/evasions/user-agent-override')
 // Define custom UA and locale
-const ua = UserAgentOverride({ userAgent: "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)", locale: "de-DE,de" })
+const ua = UserAgentOverride({
+  userAgent: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)',
+  locale: 'de-DE,de'
+})
 puppeteer.use(ua)
 ```
 
-* * *
+---


### PR DESCRIPTION
This PR adds support for UA hints to the `user-agent-override` evasion. Note that this is a breaking change, I opted to change the functionality of the evasion a bit and detect the platform (as well as the now required version, model, architecture, etc) all from the provided user agent string.

Unfortunately UA hints only work in headful (yet another reason not to use headless...), so the test needs to run in headful.