### PR TITLE
fix(plugin-stealth): Fix AutomationControlled flag override

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.webdriver/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.webdriver/index.js
@@ -27,13 +27,13 @@ class Plugin extends PuppeteerExtraPlugin {
   // To remove this bar on Linux, run: mkdir -p /etc/opt/chrome/policies/managed && echo '{ "CommandLineFlagSecurityWarningsEnabled": false }' > /etc/opt/chrome/policies/managed/managed_policies.json
   async beforeLaunch(options) {
     // If disable-blink-features is already passed, append the AutomationControlled switch
-    options.args.forEach(e => {
-      if (e.startsWith('--disable-blink-features=')) {
-        e += ',AutomationControlled'
-        return // eslint-disable-line
-      }
-    })
-    options.args.push(`--disable-blink-features=AutomationControlled`)
+    const idx = launchOptions.args.findIndex((arg) => arg.startsWith('--disable-blink-features='));
+    if (idx !== -1) {
+      const arg = launchOptions.args[idx];
+      launchOptions.args[idx] = `${arg},AutomationControlled`;
+    } else {
+      launchOptions.args.push('--disable-blink-features=AutomationControlled');
+    }
   }
 }
 

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.webdriver/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.webdriver/index.js
@@ -27,12 +27,12 @@ class Plugin extends PuppeteerExtraPlugin {
   // To remove this bar on Linux, run: mkdir -p /etc/opt/chrome/policies/managed && echo '{ "CommandLineFlagSecurityWarningsEnabled": false }' > /etc/opt/chrome/policies/managed/managed_policies.json
   async beforeLaunch(options) {
     // If disable-blink-features is already passed, append the AutomationControlled switch
-    const idx = launchOptions.args.findIndex((arg) => arg.startsWith('--disable-blink-features='));
+    const idx = options.args.findIndex((arg) => arg.startsWith('--disable-blink-features='));
     if (idx !== -1) {
-      const arg = launchOptions.args[idx];
-      launchOptions.args[idx] = `${arg},AutomationControlled`;
+      const arg = options.args[idx];
+      options.args[idx] = `${arg},AutomationControlled`;
     } else {
-      launchOptions.args.push('--disable-blink-features=AutomationControlled');
+      options.args.push('--disable-blink-features=AutomationControlled');
     }
   }
 }


### PR DESCRIPTION
This probably never affected any users, but the appending of `AutomationControlled` to existing flag would not work, because `e += ',AutomationControlled'` does not actually update the value in the `args` array, only the `e` variable inside the callback.

```js
const a = ['x','y','z'];
a.forEach(c => { c+= 'foo' } );

console.log(a) // ['x','y','z']
```

<img width="280" alt="image" src="https://user-images.githubusercontent.com/23726914/106782576-99dde000-664a-11eb-9a4f-ea0351940999.png">

I also assume the `return` on line 33 was there to break out of the loop early, but again, it doesn't do anything.

This PR fixes it by inserting a new string into the array at the original index.