### PR TITLE
chore(ci): Bump NodeJS to v15 and puppeteer to v7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,12 @@ jobs:
     strategy:
       matrix:
         node:
-          - 14
+          - 15
+          # - 14
           - 12
         puppeteer_version:
-          - 5.0.0
+          - 7.0.0 # Chromium 90.0.4403.0, Feb 3, 2021
+          # - 5.0.0 # Chromium 83.0.4103.0, Jul 2, 2020
           - 2.1.1 # Chromium 79.0.3942.0, Oct 24 2019
           # - 2.0.0 # Chromium 79.0.3942.0, Oct 24 2019
           # - 1.20.0 # Chromium 78.0.3882.0, Sep 13 2019


### PR DESCRIPTION
* Change NodeJS 14 to 15
* Change Puppeteer 5.0.0 to 7.0.0