### PR TITLE
feat(plugin-stealth): Rewrite navigator.permissions evasion

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.permissions/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.permissions/index.js
@@ -5,7 +5,9 @@ const { PuppeteerExtraPlugin } = require('puppeteer-extra-plugin')
 const withUtils = require('../_utils/withUtils')
 
 /**
- * Pass the Permissions Test.
+ * Fix `Notification.permission` behaving weirdly in headless mode
+ *
+ * @see https://bugs.chromium.org/p/chromium/issues/detail?id=1052332
  */
 
 class Plugin extends PuppeteerExtraPlugin {
@@ -17,32 +19,52 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/navigator.permissions'
   }
 
-  /* global Notification PermissionStatus */
+  /* global Notification Permissions PermissionStatus */
   async onPageCreated(page) {
     await withUtils(page).evaluateOnNewDocument((utils, opts) => {
-      const handler = {
-        apply: function(target, ctx, args) {
-          const param = (args || [])[0]
+      const isSecure = document.location.protocol.startsWith('https')
 
-          if (param && param.name && param.name === 'notifications') {
-            const result = { state: Notification.permission }
-            Object.setPrototypeOf(result, PermissionStatus.prototype)
-            return Promise.resolve(result)
+      // In headful on secure origins the permission should be "default", not "denied"
+      if (isSecure) {
+        utils.replaceGetterWithProxy(Notification, 'permission', {
+          apply() {
+            return 'default'
           }
-
-          return utils.cache.Reflect.apply(...arguments)
-        }
+        })
       }
 
-      utils.replaceWithProxy(
-        Object.getPrototypeOf(navigator.permissions),
-        'query',
-        handler
-      )
+      // Another weird behavior:
+      // On insecure origins in headful the state is "denied",
+      // whereas in headless it's "prompt"
+      if (!isSecure) {
+        const handler = {
+          apply(target, ctx, args) {
+            const param = (args || [])[0]
+
+            const isNotifications =
+              param && param.name && param.name === 'notifications'
+            if (!isNotifications) {
+              return utils.cache.Reflect.apply(...arguments)
+            }
+
+            return Promise.resolve(
+              Object.setPrototypeOf(
+                {
+                  state: 'denied',
+                  onchange: null
+                },
+                PermissionStatus.prototype
+              )
+            )
+          }
+        }
+        // Note: Don't use `Object.getPrototypeOf` here
+        utils.replaceWithProxy(Permissions.prototype, 'query', handler)
+      }
     }, this.opts)
   }
 }
 
-module.exports = function(pluginConfig) {
+module.exports = function (pluginConfig) {
   return new Plugin(pluginConfig)
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.permissions/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.permissions/index.test.js
@@ -1,17 +1,105 @@
+/* global Notification */
 const test = require('ava')
 
 const {
   getVanillaFingerPrint,
   getStealthFingerPrint
 } = require('../../test/util')
+const { vanillaPuppeteer, addExtra } = require('../../test/util')
+
 const Plugin = require('.')
 
 test('vanilla: is prompt', async t => {
   const { permissions } = await getVanillaFingerPrint()
-  t.is(permissions.state, 'prompt')
+  t.deepEqual(permissions, {
+    permission: 'denied',
+    state: 'prompt' // this is WRONG behavior, it's "denied" in headful!
+  })
 })
 
 test('stealth: is denied', async t => {
   const { permissions } = await getStealthFingerPrint(Plugin)
-  t.is(permissions.state, 'denied')
+  t.deepEqual(permissions, {
+    permission: 'denied',
+    state: 'denied' // this is FIXED behavior, it's "denied" in headful!
+  })
+})
+
+async function getNotificationPermission() {
+  const { state, onchange } = await navigator.permissions.query({
+    name: 'notifications'
+  })
+  return {
+    state,
+    onchange,
+    permission: Notification.permission
+  }
+}
+
+test('vanilla headful: as expected', async t => {
+  const puppeteer = addExtra(vanillaPuppeteer)
+  const browser = await puppeteer.launch({ headless: false })
+  const page = await browser.newPage()
+  const result = await page.evaluate(getNotificationPermission)
+  t.deepEqual(result, {
+    state: 'denied',
+    onchange: null,
+    permission: 'denied'
+  })
+
+  await page.goto('https://example.com', {
+    waitUntil: 'domcontentloaded'
+  })
+  const result2 = await page.evaluate(getNotificationPermission)
+  t.deepEqual(result2, {
+    state: 'prompt',
+    onchange: null,
+    permission: 'default'
+  })
+})
+
+test('vanilla headless: as expected', async t => {
+  const puppeteer = addExtra(vanillaPuppeteer)
+  const browser = await puppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+  const result = await page.evaluate(getNotificationPermission)
+  t.deepEqual(result, {
+    state: 'prompt', // should be denied
+    onchange: null,
+    permission: 'denied'
+  })
+
+  await page.goto('https://example.com', {
+    waitUntil: 'domcontentloaded'
+  })
+
+  const result2 = await page.evaluate(getNotificationPermission)
+  t.deepEqual(result2, {
+    state: 'prompt',
+    onchange: null,
+    permission: 'denied' // should be default
+  })
+})
+
+test('stealth headless: as vanilla headful', async t => {
+  const puppeteer = addExtra(vanillaPuppeteer).use(Plugin())
+  const browser = await puppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+  const result = await page.evaluate(getNotificationPermission)
+  t.deepEqual(result, {
+    state: 'denied',
+    onchange: null,
+    permission: 'denied'
+  })
+
+  await page.goto('https://example.com', {
+    waitUntil: 'domcontentloaded'
+  })
+
+  const result2 = await page.evaluate(getNotificationPermission)
+  t.deepEqual(result2, {
+    state: 'prompt',
+    onchange: null,
+    permission: 'default'
+  })
 })


### PR DESCRIPTION
This PR:
- fixes the `navigator.permissions` evasion

The evasion has been weird/broken from the start, which is due to buggy behavior in vanilla headless (+ different behavior on secure/insecure origins). 

This PR adds a bunch of tests and fixes the evasion so headless will behave like headful.

![image](https://user-images.githubusercontent.com/1368633/107933764-789cbe00-6f7f-11eb-8fb5-fe6961ed52a4.png)
