### PR TITLE
chore(plugin-stealth): Disable navigator.plugins in chromium 90

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/_utils/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/_utils/index.js
@@ -465,7 +465,8 @@ utils.chromiumVersion = () =>
     const fromString = (str = '') =>
       (str.match(/Chrome\/(?<version>[\d.]+)?/) || { groups: {} }).groups
         .version
-    const fromUserAgent = () => fromString(navigator?.userAgent)
+    const fromUserAgent = () =>
+      fromString(typeof navigator === 'undefined' ? '' : navigator.userAgent)
     return { compare, is, semver, fromString, fromUserAgent }
   })()
 

--- a/packages/puppeteer-extra-plugin-stealth/evasions/_utils/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/_utils/index.test.js
@@ -224,22 +224,21 @@ function toStringTest(obj) {
 - Function.prototype.toString.call(obj): ${Function.prototype.toString.call(
     obj
   )}
-- Function.prototype.valueOf.call(obj) + "": ${
-    Function.prototype.valueOf.call(obj) + ''
-  }
-- obj.toString === Function.prototype.toString: ${
-    obj.toString === Function.prototype.toString
-  }
+- Function.prototype.valueOf.call(obj) + "": ${Function.prototype.valueOf.call(
+    obj
+  ) + ''}
+- obj.toString === Function.prototype.toString: ${obj.toString ===
+    Function.prototype.toString}
 `.trim()
 }
 
 test('patchToString: passes all toString tests', async t => {
-  const toStringVanilla = await (async function () {
+  const toStringVanilla = await (async function() {
     const browser = await vanillaPuppeteer.launch({ headless: true })
     const page = await browser.newPage()
     return page.evaluate(toStringTest, 'HTMLMediaElement.prototype.canPlayType')
   })()
-  const toStringStealth = await (async function () {
+  const toStringStealth = await (async function() {
     const browser = await vanillaPuppeteer.launch({ headless: true })
     const page = await browser.newPage()
     await withUtils(page).evaluate(utils => {
@@ -277,17 +276,20 @@ test('patchToString: passes stack trace tests', async t => {
         Object.getOwnPropertyDescriptor(Function.prototype, 'toString').get
       ).toString()
     } catch (err) {
-      return err.stack.split('\n').slice(0, 2).join('|')
+      return err.stack
+        .split('\n')
+        .slice(0, 2)
+        .join('|')
     }
     return 'error not thrown'
   }
 
-  const toStringVanilla = await (async function () {
+  const toStringVanilla = await (async function() {
     const browser = await vanillaPuppeteer.launch({ headless: true })
     const page = await browser.newPage()
     return page.evaluate(toStringStackTrace)
   })()
-  const toStringStealth = await (async function () {
+  const toStringStealth = await (async function() {
     const browser = await vanillaPuppeteer.launch({ headless: true })
     const page = await browser.newPage()
     await withUtils(page).evaluate(utils => {
@@ -483,5 +485,36 @@ test('cache: will prevent leaks through overriding methods', async t => {
   t.deepEqual(results, {
     vanilla: true,
     stealth: false
+  })
+})
+
+test('chromiumVersion: will have the expected methods', async t => {
+  const browser = await vanillaPuppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+
+  const results = await withUtils(page).evaluate(utils => {
+    return {
+      fromUserAgent: !!utils.chromiumVersion().fromUserAgent(),
+      fromString: !!utils
+        .chromiumVersion()
+        .fromString(
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/88.0.4298.0 Safari/537.36'
+        ),
+      newerThan: utils
+        .chromiumVersion()
+        .is('91.0.4460.0')
+        .newerThan('88.0.4298.0'),
+      newerEqualsThan: utils
+        .chromiumVersion()
+        .is('91.0.4460.0')
+        .newerEqualThan('91.0.4460.0')
+    }
+  })
+
+  t.deepEqual(results, {
+    fromUserAgent: true,
+    fromString: true,
+    newerThan: true,
+    newerEqualsThan: true
   })
 })

--- a/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.test.js
@@ -198,16 +198,16 @@ test('stealth: it will emulate advanved contentWindow features correctly', async
       return iframe.contentWindow !== window
     })()
 
-    results.hasPlugins = (() => {
-      return iframe.contentWindow.navigator.plugins.length > 0
-    })()
+    // results.hasPlugins = (() => {
+    //   return iframe.contentWindow.navigator.plugins.length > 0
+    // })()
 
-    results.hasSameNumberOfPlugins = (() => {
-      return (
-        window.navigator.plugins.length ===
-        iframe.contentWindow.navigator.plugins.length
-      )
-    })()
+    // results.hasSameNumberOfPlugins = (() => {
+    //   return (
+    //     window.navigator.plugins.length ===
+    //     iframe.contentWindow.navigator.plugins.length
+    //   )
+    // })()
 
     results.SelfIsNotWindow = (() => {
       return iframe.contentWindow.self !== window
@@ -248,8 +248,8 @@ test('stealth: it will emulate advanved contentWindow features correctly', async
   t.true(results.descriptorsOK)
   t.true(results.doesExist)
   t.true(results.isNotAClone)
-  t.true(results.hasPlugins)
-  t.true(results.hasSameNumberOfPlugins)
+  // t.true(results.hasPlugins)
+  // t.true(results.hasSameNumberOfPlugins)
   t.true(results.SelfIsNotWindow)
   t.true(results.SelfIsNotWindowTop)
   t.true(results.TopIsNotSame)
@@ -276,7 +276,6 @@ test('regression: new method will not break recaptcha popup', async t => {
   await page.click('#tswsubmit')
   await page.waitForTimeout(1000)
 
-
   const { hasRecaptchaPopup } = await page.evaluate(() => {
     const hasRecaptchaPopup = !!document.querySelectorAll(
       `iframe[title="recaptcha challenge"]`
@@ -298,7 +297,7 @@ test('regression: old method indeed did break recaptcha popup', async t => {
   await page.evaluateOnNewDocument(() => {
     // eslint-disable-next-line
     Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
-      get: function () {
+      get: function() {
         return window
       }
     })

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.test.js
@@ -1,4 +1,4 @@
-const test = require('ava')
+let test = require('ava')
 
 const {
   getVanillaFingerPrint,
@@ -7,6 +7,12 @@ const {
 const { vanillaPuppeteer, addExtra } = require('../../test/util')
 
 const Plugin = require('.')
+
+if (~~require('puppeteer/package.json').version.split('.')[0] >= 7) {
+  // https://github.com/puppeteer/puppeteer/blob/main/docs/api.md
+  console.log('Skipping tests for chromium >= 90')
+  test = test.skip
+}
 
 test('vanilla: empty plugins, empty mimetypes', async t => {
   const { plugins, mimeTypes } = await getVanillaFingerPrint()

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/mimeTypes.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/mimeTypes.test.js
@@ -1,8 +1,14 @@
-const test = require('ava')
+let test = require('ava')
 
 const { vanillaPuppeteer, addExtra } = require('../../test/util')
 
 const Plugin = require('.')
+
+if (~~require('puppeteer/package.json').version.split('.')[0] >= 7) {
+  // https://github.com/puppeteer/puppeteer/blob/main/docs/api.md
+  console.log('Skipping tests for chromium >= 90')
+  test = test.skip
+}
 
 test('stealth: will have convincing mimeTypes', async t => {
   const puppeteer = addExtra(vanillaPuppeteer).use(Plugin())

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/plugins.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/plugins.test.js
@@ -1,4 +1,10 @@
-const test = require('ava')
+let test = require('ava')
+
+if (~~require('puppeteer/package.json').version.split('.')[0] >= 7) {
+  // https://github.com/puppeteer/puppeteer/blob/main/docs/api.md
+  console.log('Skipping tests for chromium >= 90')
+  test = test.skip
+}
 
 const { vanillaPuppeteer, addExtra } = require('../../test/util')
 

--- a/packages/puppeteer-extra-plugin-stealth/test/cat-and-mouse.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/test/cat-and-mouse.test.js
@@ -1,6 +1,10 @@
 const test = require('ava')
 
-const { vanillaPuppeteer, addExtra, compareLooseVersionStrings } = require('./util')
+const {
+  vanillaPuppeteer,
+  addExtra,
+  compareLooseVersionStrings
+} = require('./util')
 const Plugin = require('..')
 
 // Fix CI issues with old versions
@@ -17,7 +21,10 @@ test('stealth: will pass Paul Irish', async t => {
     .use(Plugin())
     .launch({ headless: true })
   const page = await browser.newPage()
-  await page.exposeFunction('compareLooseVersionStrings', compareLooseVersionStrings)
+  await page.exposeFunction(
+    'compareLooseVersionStrings',
+    compareLooseVersionStrings
+  )
   const detectionResults = await page.evaluate(detectHeadless)
   await browser.close()
 
@@ -47,7 +54,9 @@ async function detectHeadless() {
   })
 
   // navigator.webdriver behavior change since release 89.0.4339.0. See also #448
-  if (await compareLooseVersionStrings(navigator.userAgent, '89.0.4339.0') >= 0) {
+  if (
+    (await compareLooseVersionStrings(navigator.userAgent, '89.0.4339.0')) >= 0
+  ) {
     await test('navigator.webdriver is not false', _ => {
       return navigator.webdriver !== false
     })
@@ -112,9 +121,11 @@ async function detectHeadless() {
     if (permissions.hasOwnProperty('query')) return true // eslint-disable-line
   })
 
-  await test('navigator.plugins empty', _ => {
-    return navigator.plugins.length === 0
-  })
+  if ((await compareLooseVersionStrings(navigator.userAgent, '90')) < 0) {
+    await test('navigator.plugins empty', _ => {
+      return navigator.plugins.length === 0
+    })
+  }
 
   await test('navigator.languages blank', _ => {
     return navigator.languages === ''

--- a/packages/puppeteer-extra-plugin-stealth/test/cat-and-mouse.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/test/cat-and-mouse.test.js
@@ -121,7 +121,7 @@ async function detectHeadless() {
     if (permissions.hasOwnProperty('query')) return true // eslint-disable-line
   })
 
-  if ((await compareLooseVersionStrings(navigator.userAgent, '90')) < 0) {
+  if ((await compareLooseVersionStrings(navigator.userAgent, '90.0.0.0')) < 0) {
     await test('navigator.plugins empty', _ => {
       return navigator.plugins.length === 0
     })

--- a/packages/puppeteer-extra-plugin-stealth/test/cat-and-mouse.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/test/cat-and-mouse.test.js
@@ -153,7 +153,7 @@ async function detectHeadless() {
 
     // Here we would need to rerun all tests with `iframe.contentWindow` as `window`
     // Example:
-    return iframe.contentWindow.navigator.plugins.length === 0
+    // return iframe.contentWindow.navigator.plugins.length === 0
   })
 
   // This detects that a devtools protocol agent is attached.

--- a/packages/puppeteer-extra-plugin-stealth/test/fpscanner.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/test/fpscanner.test.js
@@ -50,7 +50,7 @@ test('stealth: will not fail a single fpscanner test', async t => {
     // Updated navigator.webdriver behavior breaks the fpscanner tests.
     t.is(failedChecks.length, 2)
     t.is(failedChecks[0].name, 'WEBDRIVER')
-    t.is(failedChecks[1].name, 'PLUGINS')
+    t.is(failedChecks[1].name, 'HEADCHR_PLUGINS')
   } else {
     t.is(failedChecks.length, 0)
   }

--- a/packages/puppeteer-extra-plugin-stealth/test/fpscanner.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/test/fpscanner.test.js
@@ -2,7 +2,11 @@ const test = require('ava')
 
 const fpscanner = require('fpscanner')
 
-const { getVanillaFingerPrint, getStealthFingerPrint, compareLooseVersionStrings } = require('./util')
+const {
+  getVanillaFingerPrint,
+  getStealthFingerPrint,
+  compareLooseVersionStrings
+} = require('./util')
 const Plugin = require('../.')
 
 // Fix CI issues with old versions
@@ -44,8 +48,9 @@ test('stealth: will not fail a single fpscanner test', async t => {
 
   if (compareLooseVersionStrings(fingerPrint.userAgent, '89.0.4339.0') >= 0) {
     // Updated navigator.webdriver behavior breaks the fpscanner tests.
-    t.is(failedChecks.length, 1)
+    t.is(failedChecks.length, 2)
     t.is(failedChecks[0].name, 'WEBDRIVER')
+    t.is(failedChecks[1].name, 'PLUGINS')
   } else {
     t.is(failedChecks.length, 0)
   }


### PR DESCRIPTION
Starting from chromium 90 the browser will return empty mimetypes and plugin arrays, so we don't want to spoof them then:
https://www.chromestatus.com/features/5741884322349056

v90 is stable in only 2 weeks, so it was necessary to update the stealth plugin to reflect that change.

Luckily the empty special arrays are still present in headless, so we don't even need to spoof those (canary headless):
![image](https://user-images.githubusercontent.com/1368633/112734832-7fd4c580-8f48-11eb-8cfa-fce8ad56fc47.png)

This PR:
- adds `utils.chromiumVersion` to make parsing/comparing semver easy
- disables the `navigator.plugins` evasion in v90 and up

Apologies for the noise caused by prettier :-)