### PR TITLE
fix(plugin-recaptcha): Add recaptcha.net detection support

### DIFF
--- a/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
@@ -117,6 +117,10 @@ export class RecaptchaContentScript {
         `iframe[src^='https://www.google.com/recaptcha/api2/anchor'][name^="a-"]`
         + ', ' +
         `iframe[src^='https://www.google.com/recaptcha/enterprise/anchor'][name^="a-"]`
+        + ', ' +
+        `iframe[src^='https://www.recaptcha.net/recaptcha/api2/anchor'][name^="a-"]`
+        + ', ' +
+        `iframe[src^='https://www.recaptcha.net/recaptcha/enterprise/anchor'][name^="a-"]`
       )
     )
   }
@@ -129,6 +133,14 @@ export class RecaptchaContentScript {
       `iframe[src^='https://www.google.com/recaptcha/enterprise/anchor'][name^="a-${
         id || ''
       }"]`
+      + ', ' +
+      `iframe[src^='https://www.recaptcha.net/recaptcha/api2/anchor'][name^="a-${
+        id || ''
+      }"]`
+      + ', ' +
+      `iframe[src^='https://www.recaptcha.net/recaptcha/enterprise/anchor'][name^="a-${
+        id || ''
+      }"]`
     )
   }
 
@@ -139,6 +151,14 @@ export class RecaptchaContentScript {
       }"]`
       + ', ' +
       `iframe[src^='https://www.google.com/recaptcha/enterprise/bframe'][name^="c-${
+        id || ''
+      }"]`
+      + ', ' +
+      `iframe[src^='https://www.recaptcha.net/recaptcha/api2/bframe'][name^="c-${
+        id || ''
+      }"]`
+      + ', ' +
+      `iframe[src^='https://www.recaptcha.net/recaptcha/enterprise/bframe'][name^="c-${
         id || ''
       }"]`
     )
@@ -197,6 +217,14 @@ export class RecaptchaContentScript {
             }"]`
             + ', ' +
             `iframe[src^='https://www.google.com/recaptcha/enterprise/bframe'][name^="c-${
+              id || ''
+            }"]`
+            + ', ' +
+            `iframe[src^='https://www.recaptcha.net/recaptcha/api2/bframe'][name^="c-${
+              id || ''
+            }"]`
+            + ', ' +
+            `iframe[src^='https://www.recaptcha.net/recaptcha/enterprise/bframe'][name^="c-${
               id || ''
             }"]`
           ).length


### PR DESCRIPTION
…a.net

The goal of this PR is to add support for the recaptcha plugin to also solve recaptchas served from the `recaptcha.net` domain when `google.com` is unavailable. 

This PR should not introduce any breaking changes to the recaptcha handler itself. I was hesitant to generate docs in this PR as it generated docs for many other plugins in the repo. Please let me know if there is anything I can add!

For additional information, please see [recaptcha docs](https://developers.google.com/recaptcha/docs/faq) for further information