### PR TITLE
feat(plugin-stealth): Catch and mute certain Protocol errors

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/sourceurl/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/sourceurl/index.js
@@ -27,7 +27,18 @@ class Plugin extends PuppeteerExtraPlugin {
     page._client.send = (function(originalMethod, context) {
       return async function() {
         const [method, paramArgs] = arguments || []
-        const next = () => originalMethod.apply(context, [method, paramArgs])
+        const next = async () => {
+          try {
+            return await originalMethod.apply(context, [method, paramArgs])
+          } catch(error) {
+            // This seems to happen sometimes when redirects cause other outstanding requests to be cut short
+            if (error instanceof Error && error.message.includes(`Protocol error (Network.getResponseBody): No resource with given identifier found`)) {
+              debug(`Caught and ignored an error about a missing network resource.`, { error })
+            } else {
+              throw error
+            }
+          }
+        }
 
         if (!method || !paramArgs) {
           return next()


### PR DESCRIPTION
We recently started using [`enchant-puppeteer`](https://github.com/berstend/puppeteer-extra/issues/364#issuecomment-757049890) and doing our own asynchronous request interception while also using `puppeteer-extra-plugin-stealth`.  It seems like this combination makes it much more likely for this error to happen, especially on pages with redirects. The error was causing the whole process to be killed.

This seems relevant: https://github.com/puppeteer/puppeteer/issues/2258#issuecomment-380647459

We aren’t sure this is the right way to handle this problem. However, this seems like an improvement.