### PR TITLE
feat(plugin-recaptcha): Add useEnterpriseFlag and useActionValue options

### DIFF
--- a/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
@@ -1,11 +1,11 @@
 import * as types from './types'
 
 export const ContentScriptDefaultOpts: types.ContentScriptOpts = {
-  visualFeedback: true,
+  visualFeedback: true
 }
 
 export const ContentScriptDefaultData: types.ContentScriptData = {
-  solutions: [],
+  solutions: []
 }
 
 /**
@@ -45,10 +45,10 @@ export class RecaptchaContentScript {
     let newObj = {} as any
     for (let i = 0; i < levels; i++) {
       item = Object.keys(newObj).length ? newObj : item
-      Object.keys(item).forEach((key) => {
+      Object.keys(item).forEach(key => {
         if (ignoreHTML && isHTML(item[key])) return
         if (isObject(item[key])) {
-          Object.keys(item[key]).forEach((innerKey) => {
+          Object.keys(item[key]).forEach(innerKey => {
             if (ignoreHTML && isHTML(item[key][innerKey])) return
             const keyName = isObject(item[key][innerKey])
               ? `obj_${key}_${innerKey}`
@@ -65,11 +65,11 @@ export class RecaptchaContentScript {
 
   // Helper function to return an object based on a well known value
   private _getKeyByValue(object: any, value: any) {
-    return Object.keys(object).find((key) => object[key] === value)
+    return Object.keys(object).find(key => object[key] === value)
   }
 
   private async _waitUntilDocumentReady() {
-    return new Promise(function (resolve) {
+    return new Promise(function(resolve) {
       if (!document || !window) {
         return resolve(null)
       }
@@ -114,53 +114,45 @@ export class RecaptchaContentScript {
   private _findVisibleIframeNodes() {
     return Array.from(
       document.querySelectorAll<HTMLIFrameElement>(
-        `iframe[src^='https://www.google.com/recaptcha/api2/anchor'][name^="a-"]`
-        + ', ' +
-        `iframe[src^='https://www.google.com/recaptcha/enterprise/anchor'][name^="a-"]`
-        + ', ' +
-        `iframe[src^='https://www.recaptcha.net/recaptcha/api2/anchor'][name^="a-"]`
-        + ', ' +
-        `iframe[src^='https://www.recaptcha.net/recaptcha/enterprise/anchor'][name^="a-"]`
+        `iframe[src^='https://www.google.com/recaptcha/api2/anchor'][name^="a-"]` +
+          ', ' +
+          `iframe[src^='https://www.google.com/recaptcha/enterprise/anchor'][name^="a-"]` +
+          ', ' +
+          `iframe[src^='https://www.recaptcha.net/recaptcha/api2/anchor'][name^="a-"]` +
+          ', ' +
+          `iframe[src^='https://www.recaptcha.net/recaptcha/enterprise/anchor'][name^="a-"]`
       )
     )
   }
   private _findVisibleIframeNodeById(id?: string) {
     return document.querySelector<HTMLIFrameElement>(
-      `iframe[src^='https://www.google.com/recaptcha/api2/anchor'][name^="a-${
-        id || ''
-      }"]`
-      + ', ' +
-      `iframe[src^='https://www.google.com/recaptcha/enterprise/anchor'][name^="a-${
-        id || ''
-      }"]`
-      + ', ' +
-      `iframe[src^='https://www.recaptcha.net/recaptcha/api2/anchor'][name^="a-${
-        id || ''
-      }"]`
-      + ', ' +
-      `iframe[src^='https://www.recaptcha.net/recaptcha/enterprise/anchor'][name^="a-${
-        id || ''
-      }"]`
+      `iframe[src^='https://www.google.com/recaptcha/api2/anchor'][name^="a-${id ||
+        ''}"]` +
+        ', ' +
+        `iframe[src^='https://www.google.com/recaptcha/enterprise/anchor'][name^="a-${id ||
+          ''}"]` +
+        ', ' +
+        `iframe[src^='https://www.recaptcha.net/recaptcha/api2/anchor'][name^="a-${id ||
+          ''}"]` +
+        ', ' +
+        `iframe[src^='https://www.recaptcha.net/recaptcha/enterprise/anchor'][name^="a-${id ||
+          ''}"]`
     )
   }
 
   private _hideChallengeWindowIfPresent(id?: string) {
     let frame: HTMLElement | null = document.querySelector<HTMLIFrameElement>(
-      `iframe[src^='https://www.google.com/recaptcha/api2/bframe'][name^="c-${
-        id || ''
-      }"]`
-      + ', ' +
-      `iframe[src^='https://www.google.com/recaptcha/enterprise/bframe'][name^="c-${
-        id || ''
-      }"]`
-      + ', ' +
-      `iframe[src^='https://www.recaptcha.net/recaptcha/api2/bframe'][name^="c-${
-        id || ''
-      }"]`
-      + ', ' +
-      `iframe[src^='https://www.recaptcha.net/recaptcha/enterprise/bframe'][name^="c-${
-        id || ''
-      }"]`
+      `iframe[src^='https://www.google.com/recaptcha/api2/bframe'][name^="c-${id ||
+        ''}"]` +
+        ', ' +
+        `iframe[src^='https://www.google.com/recaptcha/enterprise/bframe'][name^="c-${id ||
+          ''}"]` +
+        ', ' +
+        `iframe[src^='https://www.recaptcha.net/recaptcha/api2/bframe'][name^="c-${id ||
+          ''}"]` +
+        ', ' +
+        `iframe[src^='https://www.recaptcha.net/recaptcha/enterprise/bframe'][name^="c-${id ||
+          ''}"]`
     )
     if (!frame) {
       return
@@ -190,43 +182,39 @@ export class RecaptchaContentScript {
   private getVisibleIframesIds() {
     // Find all regular visible recaptcha boxes through their iframes
     return this._findVisibleIframeNodes()
-      .filter(($f) => this._isVisible($f))
-      .map(($f) => this._paintCaptchaBusy($f))
-      .filter(($f) => $f && $f.getAttribute('name'))
-      .map(($f) => $f.getAttribute('name') || '') // a-841543e13666
+      .filter($f => this._isVisible($f))
+      .map($f => this._paintCaptchaBusy($f))
+      .filter($f => $f && $f.getAttribute('name'))
+      .map($f => $f.getAttribute('name') || '') // a-841543e13666
       .map(
-        (rawId) => rawId.split('-').slice(-1)[0] // a-841543e13666 => 841543e13666
+        rawId => rawId.split('-').slice(-1)[0] // a-841543e13666 => 841543e13666
       )
-      .filter((id) => id)
+      .filter(id => id)
   }
 
   private getInvisibleIframesIds() {
     // Find all invisible recaptcha boxes through their iframes (only the ones with an active challenge window)
     return this._findVisibleIframeNodes()
-      .filter(($f) => $f && $f.getAttribute('name'))
-      .map(($f) => $f.getAttribute('name') || '') // a-841543e13666
+      .filter($f => $f && $f.getAttribute('name'))
+      .map($f => $f.getAttribute('name') || '') // a-841543e13666
       .map(
-        (rawId) => rawId.split('-').slice(-1)[0] // a-841543e13666 => 841543e13666
+        rawId => rawId.split('-').slice(-1)[0] // a-841543e13666 => 841543e13666
       )
-      .filter((id) => id)
+      .filter(id => id)
       .filter(
-        (id) =>
+        id =>
           document.querySelectorAll(
-            `iframe[src^='https://www.google.com/recaptcha/api2/bframe'][name^="c-${
-              id || ''
-            }"]`
-            + ', ' +
-            `iframe[src^='https://www.google.com/recaptcha/enterprise/bframe'][name^="c-${
-              id || ''
-            }"]`
-            + ', ' +
-            `iframe[src^='https://www.recaptcha.net/recaptcha/api2/bframe'][name^="c-${
-              id || ''
-            }"]`
-            + ', ' +
-            `iframe[src^='https://www.recaptcha.net/recaptcha/enterprise/bframe'][name^="c-${
-              id || ''
-            }"]`
+            `iframe[src^='https://www.google.com/recaptcha/api2/bframe'][name^="c-${id ||
+              ''}"]` +
+              ', ' +
+              `iframe[src^='https://www.google.com/recaptcha/enterprise/bframe'][name^="c-${id ||
+                ''}"]` +
+              ', ' +
+              `iframe[src^='https://www.recaptcha.net/recaptcha/api2/bframe'][name^="c-${id ||
+                ''}"]` +
+              ', ' +
+              `iframe[src^='https://www.recaptcha.net/recaptcha/enterprise/bframe'][name^="c-${id ||
+                ''}"]`
           ).length
       )
   }
@@ -235,10 +223,19 @@ export class RecaptchaContentScript {
     // Find all recaptcha boxes through their iframes, check for invisible ones as fallback
     const results = [
       ...this.getVisibleIframesIds(),
-      ...this.getInvisibleIframesIds(),
+      ...this.getInvisibleIframesIds()
     ]
     // Deduplicate results by using the unique id as key
     return [...new Map(results.map((x: any) => [x.id, x])).values()]
+  }
+
+  private isEnterpriseCaptcha(id?: string) {
+    if (!id) return
+    // The only way to determine if a captcha is an enterprise one is by looking at their iframes
+    const prefix = 'iframe[src*="/recaptcha/"][src*="/enterprise/"]'
+    const nameSelectors = [`[name^="a-${id}"]`, `[name^="c-${id}"]`]
+    const fullSelector = nameSelectors.map(name => prefix + name).join(',')
+    return document.querySelectorAll(fullSelector).length > 0
   }
 
   private getResponseInputById(id?: string) {
@@ -261,7 +258,7 @@ export class RecaptchaContentScript {
     const clients = this.getClients()
     // Lookup captcha "client" info using extracted id
     let client: any = Object.values(clients || {})
-      .filter((obj) => this._getKeyByValue(obj, id))
+      .filter(obj => this._getKeyByValue(obj, id))
       .shift() // returns first entry in array or undefined
     if (!client) return
     client = this._flattenObject(client) as any
@@ -284,8 +281,11 @@ export class RecaptchaContentScript {
       'left',
       'width',
       'height',
-      'theme',
+      'theme'
     ])(client)
+    if (client && client.action) {
+      info.action = client.action
+    }
     // callbacks can be strings or funtion refs
     if (info.callback && typeof info.callback === 'function') {
       info.callback = info.callback.name || 'anonymous'
@@ -297,22 +297,28 @@ export class RecaptchaContentScript {
   public async findRecaptchas() {
     const result = {
       captchas: [] as (types.CaptchaInfo | undefined)[],
-      error: null as any,
+      error: null as any
     }
     try {
       await this._waitUntilDocumentReady()
       const clients = this.getClients()
       if (!clients) return result
       result.captchas = this.getIframesIds()
-        .map((id) => this.getClientById(id))
-        .map((client) => this.extractInfoFromClient(client))
-        .map((info) => {
+        .map(id => this.getClientById(id))
+        .map(client => this.extractInfoFromClient(client))
+        .map(info => {
           if (!info) return
           const $input = this.getResponseInputById(info.id)
           info.hasResponseElement = !!$input
           return info
         })
-        .filter((info) => info)
+        .filter(info => info)
+        .map(info => {
+          if (this.isEnterpriseCaptcha(info.id)) {
+            info.isEnterprise = true
+          }
+          return info
+        })
     } catch (error) {
       result.error = error
       return result
@@ -323,7 +329,7 @@ export class RecaptchaContentScript {
   public async enterRecaptchaSolutions() {
     const result = {
       solved: [] as (types.CaptchaSolved | undefined)[],
-      error: null as any,
+      error: null as any
     }
     try {
       await this._waitUntilDocumentReady()
@@ -339,20 +345,20 @@ export class RecaptchaContentScript {
       }
 
       result.solved = this.getIframesIds()
-        .map((id) => this.getClientById(id))
-        .map((client) => {
+        .map(id => this.getClientById(id))
+        .map(client => {
           const solved: types.CaptchaSolved = {
             _vendor: 'recaptcha',
             id: client.id,
             responseElement: false,
-            responseCallback: false,
+            responseCallback: false
           }
           const $iframe = this._findVisibleIframeNodeById(solved.id)
           if (!$iframe) {
             solved.error = `Iframe not found for id '${solved.id}'`
             return solved
           }
-          const solution = solutions.find((s) => s.id === solved.id)
+          const solution = solutions.find(s => s.id === solved.id)
           if (!solution || !solution.text) {
             solved.error = `Solution not found for id '${solved.id}'`
             return solved

--- a/packages/puppeteer-extra-plugin-recaptcha/src/detection.test.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/detection.test.ts
@@ -30,6 +30,7 @@ test('will correctly detect v2-checkbox-auto.html', async t => {
   const c = captchas[0]
   t.is(c._vendor, 'recaptcha')
   t.is(c.callback, undefined)
+  t.is(c.isEnterprise, undefined)
   t.is(c.hasResponseElement, true)
   t.is(c.url, url)
   t.true(c.sitekey && c.sitekey.length > 5)
@@ -70,6 +71,7 @@ test('will correctly detect enterprise-checkbox-auto.html', async t => {
   const c = captchas[0]
   t.is(c._vendor, 'recaptcha')
   t.is(c.callback, undefined)
+  t.is(c.isEnterprise, true)
   t.is(c.hasResponseElement, true)
   t.is(c.url, url)
   t.true(c.sitekey && c.sitekey.length > 5)
@@ -90,6 +92,29 @@ test('will correctly detect enterprise-checkbox-auto-recaptchadotnet.html', asyn
   const c = captchas[0]
   t.is(c._vendor, 'recaptcha')
   t.is(c.callback, undefined)
+  t.is(c.isEnterprise, true)
+  t.is(c.hasResponseElement, true)
+  t.is(c.url, url)
+  t.true(c.sitekey && c.sitekey.length > 5)
+  t.is(c.widgetId, 0)
+  t.not(c.display, undefined)
+
+  await browser.close()
+})
+
+test('will correctly detect enterprise-checkbox-explicit.html', async t => {
+  const url =
+    'https://berstend.github.io/static/recaptcha/enterprise-checkbox-explicit.html'
+  const { browser, page } = await getBrowser(url)
+  const { captchas, error } = await (page as any).findRecaptchas()
+  t.is(error, null)
+  t.is(captchas.length, 1)
+
+  const c = captchas[0]
+  t.is(c._vendor, 'recaptcha')
+  t.is(c.callback, undefined)
+  t.is(c.action, 'homepage') // NOTE
+  t.is(c.isEnterprise, true)
   t.is(c.hasResponseElement, true)
   t.is(c.url, url)
   t.true(c.sitekey && c.sitekey.length > 5)

--- a/packages/puppeteer-extra-plugin-recaptcha/src/index.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/index.ts
@@ -11,8 +11,8 @@ import * as TwoCaptcha from './provider/2captcha'
 export const BuiltinSolutionProviders: types.SolutionProvider[] = [
   {
     id: TwoCaptcha.PROVIDER_ID,
-    fn: TwoCaptcha.getSolutions,
-  },
+    fn: TwoCaptcha.getSolutions
+  }
 ]
 
 /**
@@ -32,14 +32,14 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
   get defaults(): types.PluginOptions {
     return {
       visualFeedback: true,
-      throwOnError: false,
+      throwOnError: false
     }
   }
 
   get contentScriptOpts(): types.ContentScriptOpts {
     const { visualFeedback } = this.opts
     return {
-      visualFeedback,
+      visualFeedback
     }
   }
 
@@ -111,7 +111,7 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
 
     const response: types.FindRecaptchasResult = {
       captchas: [...resultRecaptcha.captchas, ...resultHcaptcha.captchas],
-      error: resultRecaptcha.error || resultHcaptcha.error,
+      error: resultRecaptcha.error || resultHcaptcha.error
     }
     this.debug('findRecaptchas', response)
     if (this.opts.throwOnError && response.error) {
@@ -136,7 +136,7 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
     let fn = provider.fn
     if (!fn) {
       const builtinProvider = BuiltinSolutionProviders.find(
-        (p) => p.id === (provider || {}).id
+        p => p.id === (provider || {}).id
       )
       if (!builtinProvider || !builtinProvider.fn) {
         throw new Error(
@@ -145,7 +145,12 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
       }
       fn = builtinProvider.fn
     }
-    const response = await fn.call(this, captchas, provider.token)
+    const response = await fn.call(
+      this,
+      captchas,
+      provider.token,
+      provider.opts || {}
+    )
     response.error =
       response.error ||
       response.solutions.find((s: types.CaptchaSolution) => !!s.error)
@@ -168,28 +173,28 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
   ) {
     this.debug('enterRecaptchaSolutions', { solutions })
 
-    const hasRecaptcha = !!solutions.find((s) => s._vendor === 'recaptcha')
+    const hasRecaptcha = !!solutions.find(s => s._vendor === 'recaptcha')
     const solvedRecaptcha: types.EnterRecaptchaSolutionsResult = hasRecaptcha
       ? ((await page.evaluate(
           this._generateContentScript('recaptcha', 'enterRecaptchaSolutions', {
-            solutions,
+            solutions
           })
         )) as any)
       : { solved: [] }
-    const hasHcaptcha = !!solutions.find((s) => s._vendor === 'hcaptcha')
+    const hasHcaptcha = !!solutions.find(s => s._vendor === 'hcaptcha')
     const solvedHcaptcha: types.EnterRecaptchaSolutionsResult = hasHcaptcha
       ? ((await page.evaluate(
           this._generateContentScript('hcaptcha', 'enterRecaptchaSolutions', {
-            solutions,
+            solutions
           })
         )) as any)
       : { solved: [] }
 
     const response: types.EnterRecaptchaSolutionsResult = {
       solved: [...solvedRecaptcha.solved, ...solvedHcaptcha.solved],
-      error: solvedRecaptcha.error || solvedHcaptcha.error,
+      error: solvedRecaptcha.error || solvedHcaptcha.error
     }
-    response.error = response.error || response.solved.find((s) => !!s.error)
+    response.error = response.error || response.solved.find(s => !!s.error)
     this.debug('enterRecaptchaSolutions', response)
     if (this.opts.throwOnError && response.error) {
       throw new Error(response.error)
@@ -205,7 +210,7 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
       captchas: [],
       solutions: [],
       solved: [],
-      error: null,
+      error: null
     }
     try {
       // If `this.opts.throwOnError` is set any of the
@@ -216,13 +221,13 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
       if (captchas.length) {
         const {
           solutions,
-          error: solutionsError,
+          error: solutionsError
         } = await this.getRecaptchaSolutions(response.captchas)
         response.solutions = solutions
 
         const {
           solved,
-          error: solvedError,
+          error: solvedError
         } = await this.enterRecaptchaSolutions(page, response.solutions)
         response.solved = solved
 
@@ -259,7 +264,7 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
     this._addCustomMethods(page)
 
     // Add custom methods to potential frames as well
-    page.on('frameattached', (frame) => {
+    page.on('frameattached', frame => {
       if (!frame) return
       this._addCustomMethods(frame)
     })

--- a/packages/puppeteer-extra-plugin-recaptcha/src/solve.test.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/solve.test.ts
@@ -6,7 +6,7 @@ import { addExtra } from 'puppeteer-extra'
 
 const PUPPETEER_ARGS = ['--no-sandbox', '--disable-setuid-sandbox']
 
-test('will solve reCAPTCHAs', async (t) => {
+test('will solve reCAPTCHAs', async t => {
   if (!process.env.TWOCAPTCHA_TOKEN) {
     t.truthy('foo')
     console.log('TWOCAPTCHA_TOKEN not set, skipping test.')
@@ -17,14 +17,14 @@ test('will solve reCAPTCHAs', async (t) => {
   const recaptchaPlugin = RecaptchaPlugin({
     provider: {
       id: '2captcha',
-      token: process.env.TWOCAPTCHA_TOKEN,
-    },
+      token: process.env.TWOCAPTCHA_TOKEN
+    }
   })
   puppeteer.use(recaptchaPlugin)
 
   const browser = await puppeteer.launch({
     args: PUPPETEER_ARGS,
-    headless: true,
+    headless: true
   })
   const page = await browser.newPage()
 
@@ -45,7 +45,7 @@ test('will solve reCAPTCHAs', async (t) => {
   await browser.close()
 })
 
-test('will solve hCAPTCHAs', async (t) => {
+test('will solve hCAPTCHAs', async t => {
   if (!process.env.TWOCAPTCHA_TOKEN) {
     t.truthy('foo')
     console.log('TWOCAPTCHA_TOKEN not set, skipping test.')
@@ -56,14 +56,14 @@ test('will solve hCAPTCHAs', async (t) => {
   const recaptchaPlugin = RecaptchaPlugin({
     provider: {
       id: '2captcha',
-      token: process.env.TWOCAPTCHA_TOKEN,
-    },
+      token: process.env.TWOCAPTCHA_TOKEN
+    }
   })
   puppeteer.use(recaptchaPlugin)
 
   const browser = await puppeteer.launch({
     args: PUPPETEER_ARGS,
-    headless: true,
+    headless: true
   })
   const page = await browser.newPage()
 
@@ -78,6 +78,49 @@ test('will solve hCAPTCHAs', async (t) => {
   t.is(solutions.length, 1)
   t.is(solved.length, 1)
   t.is(solved[0]._vendor, 'hcaptcha')
+  t.is(solved[0].isSolved, true)
+
+  await browser.close()
+})
+
+test('will solve reCAPTCHA enterprise', async t => {
+  if (!process.env.TWOCAPTCHA_TOKEN) {
+    t.truthy('foo')
+    console.log('TWOCAPTCHA_TOKEN not set, skipping test.')
+    return
+  }
+
+  const puppeteer = addExtra(require('puppeteer'))
+  const recaptchaPlugin = RecaptchaPlugin({
+    provider: {
+      id: '2captcha',
+      token: process.env.TWOCAPTCHA_TOKEN,
+      opts: {
+        useEnterpriseFlag: false // Not sure but using the enterprise flag makes it worse
+      }
+    }
+  })
+  puppeteer.use(recaptchaPlugin)
+
+  const browser = await puppeteer.launch({
+    args: PUPPETEER_ARGS,
+    headless: true
+  })
+  const page = await browser.newPage()
+
+  const url =
+    'https://berstend.github.io/static/recaptcha/enterprise-checkbox-explicit.html'
+  await page.goto(url, { waitUntil: 'networkidle0' })
+
+  const result = await (page as any).solveRecaptchas()
+
+  const { captchas, solutions, solved, error } = result
+  t.falsy(error)
+
+  t.is(captchas.length, 1)
+  t.is(solutions.length, 1)
+  t.is(solved.length, 1)
+  t.is(solved[0]._vendor, 'recaptcha')
   t.is(solved[0].isSolved, true)
 
   await browser.close()

--- a/packages/puppeteer-extra-plugin-recaptcha/src/types.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/types.ts
@@ -30,10 +30,11 @@ export type RecaptchaPluginPageAdditions = {
   solveRecaptchas: () => Promise<SolveRecaptchasResult>
 }
 
-export interface SolutionProvider {
+export interface SolutionProvider<TOpts = any> {
   id?: string
   token?: string
   fn?: (captchas: CaptchaInfo[], token?: string) => Promise<GetSolutionsResult>
+  opts?: TOpts // Optional options ;-)
 }
 
 export interface FindRecaptchasResult {
@@ -61,6 +62,8 @@ export interface CaptchaInfo {
   widgetId?: number
   sitekey?: string
   s?: string // new google site specific property
+  isEnterprise?: boolean
+  action?: string // Optional action (v3/enterprise): https://developers.google.com/recaptcha/docs/v3#actions
   callback?: string | Function
   hasResponseElement?: boolean
   url?: string


### PR DESCRIPTION
This PR is based on [previous discussions](https://github.com/berstend/puppeteer-extra/pull/400#issuecomment-823183394).

The main idea is to pass `enterprise=1` to 2captcha when an enterprise recaptcha is being detected. According to @divinedeveloper using the enterprise flag improved his success rate on hulu.com.

Unfortunately in my own testing (using my own [test sites](https://github.com/berstend/berstend.github.io/tree/main/static/recaptcha)) setting the enterprise flag made things worse (`ERROR_CAPTCHA_UNSOLVABLE`) so I'm keeping this opt-in for now, until we fully understood why this flag is not always improving the solving success rate.

In addition I added support for passing the optional `action` parameter (v3/enterprise) to 2captcha, this is opt-out as it didn't make a negative difference in my testing.

### Usage

```js
  const recaptchaPlugin = RecaptchaPlugin({
    provider: {
      id: '2captcha',
      token: process.env.TWOCAPTCHA_TOKEN,
      opts: {
        useEnterpriseFlag: false, // default: false
		useActionValue: true // default: true
      }
    }
  })
  puppeteer.use(recaptchaPlugin)
```

(Apologies for the linting noise)