### PR TITLE
feat(plugin-recaptcha): Support more recaptcha domain combos

### DIFF
--- a/packages/puppeteer-extra-plugin-recaptcha/src/detection.test.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/detection.test.ts
@@ -40,6 +40,26 @@ test('will correctly detect v2-checkbox-auto.html', async t => {
   await browser.close()
 })
 
+test('will correctly detect v2-checkbox-auto-nowww.html', async t => {
+  const url =
+    'https://berstend.github.io/static/recaptcha/v2-checkbox-auto-nowww.html'
+  const { browser, page } = await getBrowser(url)
+  const { captchas, error } = await (page as any).findRecaptchas()
+  t.is(error, null)
+  t.is(captchas.length, 1)
+
+  const c = captchas[0]
+  t.is(c._vendor, 'recaptcha')
+  t.is(c.callback, undefined)
+  t.is(c.hasResponseElement, true)
+  t.is(c.url, url)
+  t.true(c.sitekey && c.sitekey.length > 5)
+  t.is(c.widgetId, 0)
+  t.not(c.display, undefined)
+
+  await browser.close()
+})
+
 test('will correctly detect v2-checkbox-auto-recaptchadotnet.html', async t => {
   const url =
     'https://berstend.github.io/static/recaptcha/v2-checkbox-auto-recaptchadotnet.html'

--- a/packages/puppeteer-extra-plugin-recaptcha/tsconfig.json
+++ b/packages/puppeteer-extra-plugin-recaptcha/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es2017",
     "module": "es2015",
     "moduleResolution": "node",
-    "lib": ["es2015", "es2016", "es2017", "dom"],
+    "lib": ["es2015", "es2016", "es2017", "es2019", "dom"],
     // "noResolve": true, // Important: Otherwise TS would rewrite our ambient d.ts file locations (see: yarn copy-dts) :(
     "sourceMap": true,
     "declaration": true,


### PR DESCRIPTION
Based on [this discussion](https://github.com/berstend/puppeteer-extra/pull/482#issuecomment-826281337) and a follow up to #482.

At the end of the day there are more possible URLs for the recaptcha scripts to originate from (with/without www, using http or https, etc). 

This PR refactors the selector stuff to use a generator, which means we now support a grand total (and hopefully final) number of 16 recaptcha domains 😄 

![image](https://user-images.githubusercontent.com/1368633/115995168-6cb22580-a5da-11eb-9e59-1b489c57c4c4.png)
