### PR TITLE
Support Yarn V2 PnP

### DIFF
--- a/packages/puppeteer-extra-plugin-adblocker/package.json
+++ b/packages/puppeteer-extra-plugin-adblocker/package.json
@@ -44,7 +44,6 @@
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/node-fetch": "^2.5.4",
-    "@types/puppeteer": "5.4.3",
     "ava": "^2.4.0",
     "npm-run-all": "^4.1.5",
     "puppeteer": "2.0.0",
@@ -58,11 +57,13 @@
   "dependencies": {
     "@cliqz/adblocker-puppeteer": "1.18.7",
     "@types/chrome": "0.0.91",
+    "@types/puppeteer": "5.4.3",
     "debug": "^4.1.1",
     "node-fetch": "^2.6.0",
     "puppeteer-extra-plugin": "^3.1.9"
   },
   "peerDependencies": {
+    "puppeteer": "5.x || 6.x || 7.x || 8.x",
     "puppeteer-extra": "*"
   },
   "gitHead": "72fe830c158f1e971c8499fdd5232338dd53c220"

--- a/packages/puppeteer-extra-plugin-adblocker/package.json
+++ b/packages/puppeteer-extra-plugin-adblocker/package.json
@@ -63,7 +63,7 @@
     "puppeteer-extra-plugin": "^3.1.9"
   },
   "peerDependencies": {
-    "puppeteer": "5.x || 6.x || 7.x || 8.x",
+    "puppeteer": "*",
     "puppeteer-extra": "*"
   },
   "gitHead": "72fe830c158f1e971c8499fdd5232338dd53c220"

--- a/packages/puppeteer-extra-plugin-adblocker/src/index.ts
+++ b/packages/puppeteer-extra-plugin-adblocker/src/index.ts
@@ -34,6 +34,10 @@ export class PuppeteerExtraPluginAdblocker extends PuppeteerExtraPlugin {
     return 'adblocker'
   }
 
+  get filename() {
+    return __filename
+  }
+
   get defaults(): PluginOptions {
     return {
       blockTrackers: false,

--- a/packages/puppeteer-extra-plugin-anonymize-ua/index.js
+++ b/packages/puppeteer-extra-plugin-anonymize-ua/index.js
@@ -30,6 +30,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'anonymize-ua'
   }
 
+  get filename() {
+    return __filename
+  }
+
   get defaults() {
     return {
       stripHeadless: true,

--- a/packages/puppeteer-extra-plugin-anonymize-ua/package.json
+++ b/packages/puppeteer-extra-plugin-anonymize-ua/package.json
@@ -37,5 +37,8 @@
     "debug": "^4.1.1",
     "puppeteer-extra-plugin": "^3.1.9"
   },
+  "peerDependencies": {
+    "puppeteer-extra": "*"
+  },
   "gitHead": "babb041828cab50c525e0b9aab02d58f73416ef3"
 }

--- a/packages/puppeteer-extra-plugin-block-resources/index.js
+++ b/packages/puppeteer-extra-plugin-block-resources/index.js
@@ -47,6 +47,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'block-resources'
   }
 
+  get filename() {
+    return __filename
+  }
+
   get defaults() {
     return {
       availableTypes: new Set([

--- a/packages/puppeteer-extra-plugin-block-resources/package.json
+++ b/packages/puppeteer-extra-plugin-block-resources/package.json
@@ -35,5 +35,8 @@
     "debug": "^4.1.1",
     "puppeteer-extra-plugin": "^3.1.9"
   },
+  "peerDependencies": {
+    "puppeteer-extra": "*"
+  },
   "gitHead": "babb041828cab50c525e0b9aab02d58f73416ef3"
 }

--- a/packages/puppeteer-extra-plugin-click-and-wait/index.js
+++ b/packages/puppeteer-extra-plugin-click-and-wait/index.js
@@ -30,6 +30,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'click-and-wait'
   }
 
+  get filename() {
+    return __filename
+  }
+
   async clickAndWaitForNavigation(selector, clickOptions, waitOptions) {
     return Promise.all([
       this.waitForNavigation(waitOptions),

--- a/packages/puppeteer-extra-plugin-click-and-wait/package.json
+++ b/packages/puppeteer-extra-plugin-click-and-wait/package.json
@@ -33,5 +33,8 @@
     "debug": "^4.1.1",
     "puppeteer-extra-plugin": "^3.1.9"
   },
+  "peerDependencies": {
+    "puppeteer-extra": "*"
+  },
   "gitHead": "babb041828cab50c525e0b9aab02d58f73416ef3"
 }

--- a/packages/puppeteer-extra-plugin-devtools/index.js
+++ b/packages/puppeteer-extra-plugin-devtools/index.js
@@ -43,6 +43,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'devtools'
   }
 
+  get filename() {
+    return __filename
+  }
+
   get defaults() {
     return {
       prefix: 'devtools-tunnel',

--- a/packages/puppeteer-extra-plugin-devtools/package.json
+++ b/packages/puppeteer-extra-plugin-devtools/package.json
@@ -47,5 +47,8 @@
     "randomstring": "^1.1.5",
     "url-parse": "^1.4.0"
   },
+  "peerDependencies": {
+    "puppeteer-extra": "*"
+  },
   "gitHead": "babb041828cab50c525e0b9aab02d58f73416ef3"
 }

--- a/packages/puppeteer-extra-plugin-flash/index.js
+++ b/packages/puppeteer-extra-plugin-flash/index.js
@@ -37,6 +37,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'flash'
   }
 
+  get filename() {
+    return __filename
+  }
+
   get defaults() {
     return {
       allowFlash: true,

--- a/packages/puppeteer-extra-plugin-flash/package.json
+++ b/packages/puppeteer-extra-plugin-flash/package.json
@@ -34,5 +34,8 @@
     "debug": "^4.1.1",
     "puppeteer-extra-plugin": "^3.1.9"
   },
+  "peerDependencies": {
+    "puppeteer-extra": "*"
+  },
   "gitHead": "babb041828cab50c525e0b9aab02d58f73416ef3"
 }

--- a/packages/puppeteer-extra-plugin-font-size/index.js
+++ b/packages/puppeteer-extra-plugin-font-size/index.js
@@ -24,6 +24,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'font-size'
   }
 
+  get filename() {
+    return __filename
+  }
+
   get defaults() {
     return { defaultFontSize: 20 }
   }

--- a/packages/puppeteer-extra-plugin-font-size/package.json
+++ b/packages/puppeteer-extra-plugin-font-size/package.json
@@ -32,5 +32,8 @@
     "debug": "^4.1.1",
     "puppeteer-extra-plugin": "^3.1.9"
   },
+  "peerDependencies": {
+    "puppeteer-extra": "*"
+  },
   "gitHead": "babb041828cab50c525e0b9aab02d58f73416ef3"
 }

--- a/packages/puppeteer-extra-plugin-recaptcha/src/index.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/index.ts
@@ -34,6 +34,10 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
     return 'recaptcha'
   }
 
+  get filename() {
+    return __filename
+  }
+
   get defaults(): types.PluginOptions {
     return {
       visualFeedback: true,

--- a/packages/puppeteer-extra-plugin-repl/index.js
+++ b/packages/puppeteer-extra-plugin-repl/index.js
@@ -44,6 +44,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'repl'
   }
 
+  get filename() {
+    return __filename
+  }
+
   get defaults() {
     return { addToPuppeteerClass: true }
   }

--- a/packages/puppeteer-extra-plugin-repl/package.json
+++ b/packages/puppeteer-extra-plugin-repl/package.json
@@ -41,5 +41,8 @@
     "ow": "^0.4.0",
     "puppeteer-extra-plugin": "^3.1.9"
   },
+  "peerDependencies": {
+    "puppeteer-extra": "*"
+  },
   "gitHead": "babb041828cab50c525e0b9aab02d58f73416ef3"
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/_template/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/_template/index.js
@@ -16,6 +16,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/_template'
   }
 
+  get filename() {
+    return __filename
+  }
+
   async onPageCreated(page) {
     await page.evaluateOnNewDocument(() => {
       console.debug('hello world')

--- a/packages/puppeteer-extra-plugin-stealth/evasions/_template/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/_template/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "puppeteer-extra-plugin": "^3.1.9"
+  }
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/chrome.app/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/chrome.app/index.js
@@ -16,6 +16,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/chrome.app'
   }
 
+  get filename() {
+    return __filename
+  }
+
   async onPageCreated(page) {
     await withUtils(page).evaluateOnNewDocument(utils => {
       if (!window.chrome) {

--- a/packages/puppeteer-extra-plugin-stealth/evasions/chrome.app/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/chrome.app/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "puppeteer-extra-plugin": "^3.1.9"
+  }
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/chrome.csi/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/chrome.csi/index.js
@@ -30,6 +30,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/chrome.csi'
   }
 
+  get filename() {
+    return __filename
+  }
+
   async onPageCreated(page) {
     await withUtils(page).evaluateOnNewDocument(utils => {
       if (!window.chrome) {

--- a/packages/puppeteer-extra-plugin-stealth/evasions/chrome.csi/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/chrome.csi/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "puppeteer-extra-plugin": "^3.1.9"
+  }
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/chrome.loadTimes/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/chrome.loadTimes/index.js
@@ -28,6 +28,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/chrome.loadTimes'
   }
 
+  get filename() {
+    return __filename
+  }
+
   async onPageCreated(page) {
     await withUtils(page).evaluateOnNewDocument(
       (utils, { opts }) => {

--- a/packages/puppeteer-extra-plugin-stealth/evasions/chrome.loadTimes/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/chrome.loadTimes/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "puppeteer-extra-plugin": "^3.1.9"
+  }
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/chrome.runtime/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/chrome.runtime/index.js
@@ -18,6 +18,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/chrome.runtime'
   }
 
+  get filename() {
+    return __filename
+  }
+
   get defaults() {
     return { runOnInsecureOrigins: false } // Override for testing
   }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/chrome.runtime/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/chrome.runtime/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "puppeteer-extra-plugin": "^3.1.9"
+  }
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.js
@@ -19,6 +19,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/iframe.contentWindow'
   }
 
+  get filename() {
+    return __filename
+  }
+
   get requirements() {
     // Make sure `chrome.runtime` has ran, we use data defined by it (e.g. `window.chrome`)
     return new Set(['runLast'])

--- a/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "puppeteer-extra-plugin": "^3.1.9"
+  }
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/media.codecs/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/media.codecs/index.js
@@ -17,6 +17,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/media.codecs'
   }
 
+  get filename() {
+    return __filename
+  }
+
   async onPageCreated(page) {
     await withUtils(page).evaluateOnNewDocument(utils => {
       /**

--- a/packages/puppeteer-extra-plugin-stealth/evasions/media.codecs/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/media.codecs/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "puppeteer-extra-plugin": "^3.1.9"
+  }
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.hardwareConcurrency/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.hardwareConcurrency/index.js
@@ -22,6 +22,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/navigator.hardwareConcurrency'
   }
 
+  get filename() {
+    return __filename
+  }
+
   get defaults() {
     return {
       hardwareConcurrency: 4

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.hardwareConcurrency/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.hardwareConcurrency/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "puppeteer-extra-plugin": "^3.1.9"
+  }
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.languages/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.languages/index.js
@@ -18,6 +18,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/navigator.languages'
   }
 
+  get filename() {
+    return __filename
+  }
+
   get defaults() {
     return {
       languages: [] // Empty default, otherwise this would be merged with user defined array override

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.languages/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.languages/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "puppeteer-extra-plugin": "^3.1.9"
+  }
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.permissions/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.permissions/index.js
@@ -19,6 +19,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/navigator.permissions'
   }
 
+  get filename() {
+    return __filename
+  }
+
   /* global Notification Permissions PermissionStatus */
   async onPageCreated(page) {
     await withUtils(page).evaluateOnNewDocument((utils, opts) => {

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.permissions/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.permissions/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "puppeteer-extra-plugin": "^3.1.9"
+  }
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/index.js
@@ -32,6 +32,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/navigator.plugins'
   }
 
+  get filename() {
+    return __filename
+  }
+
   async onPageCreated(page) {
     await withUtils(page).evaluateOnNewDocument(
       (utils, { fns, data }) => {

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.plugins/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "puppeteer-extra-plugin": "^3.1.9"
+  }
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.vendor/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.vendor/index.js
@@ -36,6 +36,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/navigator.vendor'
   }
 
+  get filename() {
+    return __filename
+  }
+
   get defaults() {
     return {
       vendor: 'Google Inc.'

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.vendor/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.vendor/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "puppeteer-extra-plugin": "^3.1.9"
+  }
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.webdriver/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.webdriver/index.js
@@ -15,6 +15,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/navigator.webdriver'
   }
 
+  get filename() {
+    return __filename
+  }
+
   async onPageCreated(page) {
     await page.evaluateOnNewDocument(() => {
       if (navigator.webdriver === false) {

--- a/packages/puppeteer-extra-plugin-stealth/evasions/navigator.webdriver/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/navigator.webdriver/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "puppeteer-extra-plugin": "^3.1.9"
+  }
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/sourceurl/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/sourceurl/index.js
@@ -15,6 +15,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/sourceurl'
   }
 
+  get filename() {
+    return __filename
+  }
+
   async onPageCreated(page) {
     if (!page || !page._client || !page._client.send) {
       this.debug('Warning, missing properties to intercept CDP.', { page })

--- a/packages/puppeteer-extra-plugin-stealth/evasions/sourceurl/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/sourceurl/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "puppeteer-extra-plugin": "^3.1.9"
+  }
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
@@ -50,6 +50,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/user-agent-override'
   }
 
+  get filename() {
+    return __filename
+  }
+
   get dependencies() {
     return new Set(['user-preferences'])
   }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "puppeteer-extra-plugin": "^3.1.9"
+  }
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "main": "index.js",
   "dependencies": {
-    "puppeteer-extra-plugin": "^3.1.9"
+    "puppeteer-extra-plugin": "^3.1.9",
+    "puppeteer-extra-plugin-user-preferences": "^2.2.12"
   }
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/webgl.vendor/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/webgl.vendor/index.js
@@ -22,6 +22,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/webgl.vendor'
   }
 
+  get filename() {
+    return __filename
+  }
+
   /* global WebGLRenderingContext WebGL2RenderingContext */
   async onPageCreated(page) {
     await withUtils(page).evaluateOnNewDocument((utils, opts) => {

--- a/packages/puppeteer-extra-plugin-stealth/evasions/webgl.vendor/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/webgl.vendor/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "puppeteer-extra-plugin": "^3.1.9"
+  }
 }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/window.outerdimensions/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/window.outerdimensions/index.js
@@ -15,6 +15,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'stealth/evasions/window.outerdimensions'
   }
 
+  get filename() {
+    return __filename
+  }
+
   async onPageCreated(page) {
     // Chrome returns undefined, Firefox false
     await page.evaluateOnNewDocument(() => {

--- a/packages/puppeteer-extra-plugin-stealth/evasions/window.outerdimensions/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/window.outerdimensions/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "puppeteer-extra-plugin": "^3.1.9"
+  }
 }

--- a/packages/puppeteer-extra-plugin-stealth/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/index.js
@@ -78,6 +78,10 @@ class StealthPlugin extends PuppeteerExtraPlugin {
     return 'stealth'
   }
 
+  get filename() {
+    return __filename
+  }
+
   get defaults() {
     const availableEvasions = new Set([
       'chrome.app',

--- a/packages/puppeteer-extra-plugin-stealth/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/package.json
@@ -55,5 +55,8 @@
     "puppeteer-extra-plugin": "^3.1.9",
     "puppeteer-extra-plugin-user-preferences": "^2.2.12"
   },
+  "peerDependencies": {
+    "puppeteer-extra": "*"
+  },
   "gitHead": "babb041828cab50c525e0b9aab02d58f73416ef3"
 }

--- a/packages/puppeteer-extra-plugin-user-data-dir/index.js
+++ b/packages/puppeteer-extra-plugin-user-data-dir/index.js
@@ -40,6 +40,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'user-data-dir'
   }
 
+  get filename() {
+    return __filename
+  }
+
   get requirements() {
     return new Set(['runLast', 'dataFromPlugins'])
   }

--- a/packages/puppeteer-extra-plugin-user-data-dir/package.json
+++ b/packages/puppeteer-extra-plugin-user-data-dir/package.json
@@ -36,5 +36,8 @@
     "fs-extra": "^9.1.0",
     "puppeteer-extra-plugin": "^3.1.9"
   },
+  "peerDependencies": {
+    "puppeteer-extra": "*"
+  },
   "gitHead": "babb041828cab50c525e0b9aab02d58f73416ef3"
 }

--- a/packages/puppeteer-extra-plugin-user-preferences/index.js
+++ b/packages/puppeteer-extra-plugin-user-preferences/index.js
@@ -43,6 +43,10 @@ class Plugin extends PuppeteerExtraPlugin {
     return 'user-preferences'
   }
 
+  get filename() {
+    return __filename
+  }
+
   get requirements() {
     return new Set(['runLast', 'dataFromPlugins'])
   }

--- a/packages/puppeteer-extra-plugin-user-preferences/package.json
+++ b/packages/puppeteer-extra-plugin-user-preferences/package.json
@@ -36,5 +36,8 @@
     "puppeteer-extra-plugin": "^3.1.9",
     "puppeteer-extra-plugin-user-data-dir": "^2.2.12"
   },
+  "peerDependencies": {
+    "puppeteer-extra": "*"
+  },
   "gitHead": "babb041828cab50c525e0b9aab02d58f73416ef3"
 }

--- a/packages/puppeteer-extra-plugin/package.json
+++ b/packages/puppeteer-extra-plugin/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@types/node": "^13.1.4",
     "@types/puppeteer": "5.4.3",
+    "@types/pnpapi": "^0.0.1",
     "ava": "2.4.0",
     "documentation-markdown-themes": "^12.1.5",
     "npm-run-all": "^4.1.5",

--- a/packages/puppeteer-extra-plugin/src/index.ts
+++ b/packages/puppeteer-extra-plugin/src/index.ts
@@ -461,7 +461,7 @@ export abstract class PuppeteerExtraPlugin {
   _getMissingDependencies(plugins: any) {
     const pluginNames = new Set(plugins.map((p: any) => p.name))
     const missing = new Set(
-      Array.from(this.dependencies.values()).filter((x) => !pluginNames.has(x))
+      Array.from(this.dependencies.values()).filter((x) => !pluginNames.has(x)).map((x) => ({ name: x, requiredBy: this.name }))
     )
     return missing
   }

--- a/packages/puppeteer-extra-plugin/src/index.ts
+++ b/packages/puppeteer-extra-plugin/src/index.ts
@@ -94,6 +94,18 @@ export abstract class PuppeteerExtraPlugin {
   }
 
   /**
+   * Plugin filename (required).
+   *
+   * For Yarn PnP to resolve dependencies.
+   *
+   * @example
+   * get filename () { return __filename }
+   */
+  get filename(): string {
+    throw new Error('Plugin must override "filename" with __filename')
+  }
+
+  /**
    * Plugin defaults (optional).
    *
    * If defined will be ([deep-](https://github.com/jonschlinkert/merge-deep))merged with the (optional) user supplied options (supplied during plugin instantiation).
@@ -461,7 +473,7 @@ export abstract class PuppeteerExtraPlugin {
   _getMissingDependencies(plugins: any) {
     const pluginNames = new Set(plugins.map((p: any) => p.name))
     const missing = new Set(
-      Array.from(this.dependencies.values()).filter((x) => !pluginNames.has(x)).map((x) => ({ name: x, requiredBy: this.name }))
+      Array.from(this.dependencies.values()).filter((x) => !pluginNames.has(x)).map((x) => ({ name: x, requiredBy: this.filename }))
     )
     return missing
   }

--- a/packages/puppeteer-extra/readme.md
+++ b/packages/puppeteer-extra/readme.md
@@ -100,22 +100,6 @@ puppeteer
 
 </details>
 <details>
- <summary><strong>Yarn Plug'n'play usage</strong></summary><br/>
-
-> Plug'n'play is supported if Yarn v2.3.0 or later is installed.
-> 
-> Otherwise, you will need to add the plugins & it's dependencies into the `packageExtensions` in the `yarnrc.yml` so puppeteer-extra can import them.
-
-```yaml
-packageExtensions:
-  puppeteer-extra@*:
-    dependencies:
-      puppeteer-extra-plugin-adblocker: "*"
-      puppeteer-extra-plugin-stealth: "*"
-```
-
-</details>
-<details>
  <summary><strong>Multiple puppeteers with different plugins</strong></summary><br/>
 
 ```js

--- a/packages/puppeteer-extra/readme.md
+++ b/packages/puppeteer-extra/readme.md
@@ -104,7 +104,7 @@ puppeteer
 
 > Plug'n'play is supported if Yarn v2.3.0 or later is installed.
 > 
-> Otherwise, you will need to add the plugins & it's dependencies into the`packageExtensions` in the `yarnrc.yml` so puppeteer-extra can import them.
+> Otherwise, you will need to add the plugins & it's dependencies into the `packageExtensions` in the `yarnrc.yml` so puppeteer-extra can import them.
 
 ```yaml
 packageExtensions:

--- a/packages/puppeteer-extra/readme.md
+++ b/packages/puppeteer-extra/readme.md
@@ -99,7 +99,22 @@ puppeteer
 ![typings](https://i.imgur.com/bNtuTOt.png 'Typings')
 
 </details>
+<details>
+ <summary><strong>Yarn Plug'n'play usage</strong></summary><br/>
 
+> Plug'n'play is supported if Yarn v2.3.0 or later is installed.
+> 
+> Otherwise, you will need to add the plugins & it's dependencies into the`packageExtensions` in the `yarnrc.yml` so puppeteer-extra can import them.
+
+```yaml
+packageExtensions:
+  puppeteer-extra@*:
+    dependencies:
+      puppeteer-extra-plugin-adblocker: "*"
+      puppeteer-extra-plugin-stealth: "*"
+```
+
+</details>
 <details>
  <summary><strong>Multiple puppeteers with different plugins</strong></summary><br/>
 

--- a/packages/puppeteer-extra/src/index.ts
+++ b/packages/puppeteer-extra/src/index.ts
@@ -365,7 +365,7 @@ export class PuppeteerExtra implements VanillaPuppeteer {
       let dep = null
 
       const pnpInUse = process.versions.pnp != null;
-      const yarnExtensionsInstalled = require('pnpapi').VERSIONS.getAllLocators != null;
+      const yarnExtensionsInstalled = pnpInUse && require('pnpapi').VERSIONS.getAllLocators != null;
 
       try {
         // Try to require and instantiate the stated dependency

--- a/packages/puppeteer-extra/src/index.ts
+++ b/packages/puppeteer-extra/src/index.ts
@@ -356,9 +356,6 @@ export class PuppeteerExtra implements VanillaPuppeteer {
       name = name.startsWith('puppeteer-extra-plugin')
         ? name
         : `puppeteer-extra-plugin-${name}`
-      requiredBy = requiredBy.startsWith('puppeteer-extra-plugin')
-        ? requiredBy
-        : `puppeteer-extra-plugin-${requiredBy}`
       // In case a module sub resource is requested print out the main package name
       // e.g. puppeteer-extra-plugin-stealth/evasions/console.debug => puppeteer-extra-plugin-stealth
       const packageName = name.split('/')[0]
@@ -415,14 +412,8 @@ export class PuppeteerExtra implements VanillaPuppeteer {
    */
   private resolvePnpPlugin(pluginName: string, requiredBy: string) {
     const pnpapi = require('pnpapi');
-    const requiredByPackageName = requiredBy.split('/')[0]
 
-    const packageList = pnpapi.getAllLocators();
-    const requiredByPackageLocators = packageList.filter((pack: any) => pack.name === requiredByPackageName);
-    const requiredByPossiblePackageInfos = requiredByPackageLocators.map((locator: any) => pnpapi.getPackageInformation(locator));
-    const selectedLocator = requiredByPossiblePackageInfos.find((info: any) => info.linkType === 'HARD') || requiredByPossiblePackageInfos[0];
-
-    const pluginResolution = pnpapi.resolveRequest(pluginName, selectedLocator.packageLocation);
+    const pluginResolution = pnpapi.resolveRequest(pluginName, requiredBy);
 
     return require(pluginResolution)();
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2145,6 +2145,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/pnpapi@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@types/pnpapi/-/pnpapi-0.0.1.tgz#86f7f9e166e1c0b4891d365e3382a09b99642527"
+  integrity sha512-EgO0GdWEV999f2lTFl5PZZ2SF9mElSnIx76F1THQDB55lhk2I8J/1+RFojjlTO24RlAADJSm9231Vo5Wdi/NWQ==
+
 "@types/puppeteer@5.4.3":
   version "5.4.3"
   resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-5.4.3.tgz#cdca84aa7751d77448d8a477dbfa0af1f11485f2"


### PR DESCRIPTION
This PR adds support for Yarn V2's PnP.  Also adds some missing dependencies that Yarn V2 would complain about.

Full changes:
* Add Yarn V2 PnP support
* Add missing peer dependencies that Yarn would complain about
* [plugin-adblocker] Move puppeteers types into dependencies for fix TS typing issue