### PR TITLE
fs.rmdirSync() deprecated, use rmSync()

### DIFF
--- a/packages/puppeteer-extra-plugin-user-data-dir/index.js
+++ b/packages/puppeteer-extra-plugin-user-data-dir/index.js
@@ -69,7 +69,7 @@ class Plugin extends PuppeteerExtraPlugin {
     try {
       // We're doing it sync to improve chances to cleanup
       // correctly in the event of ultimate disaster.
-      fse.rmdirSync(this._userDataDir, { recursive: true })
+      fse.rmSync(this._userDataDir, { recursive: true })
     } catch (e) {
       debug(e)
     }


### PR DESCRIPTION
We get this warning from **puppeteer-extra-plugin-user-data-dir**:
```bash
(node:52638) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead (Use `node --trace-deprecation ...` to show where the warning was created)
```

Swaps `fse.rmdirSync()` with `fse.rmSync()`, which has identical behavior (both throw error when dir does not exist, both recursively remove subdirectories and files), successfully eliminates warning.