### PR TITLE
fix(plugin-stealth): Make makeHandler consistent with real getters

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/_utils/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/_utils/index.js
@@ -489,7 +489,7 @@ utils.makeHandler = () => ({
     apply(target, ctx, args) {
       // Let's fetch the value first, to trigger and escalate potential errors
       // Illegal invocations like `navigator.__proto__.vendor` will throw here
-      ret = utils.cache.Reflect.apply(...arguments)
+      utils.cache.Reflect.apply(...arguments)
       return value
     }
   })

--- a/packages/puppeteer-extra-plugin-stealth/evasions/_utils/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/_utils/index.js
@@ -489,11 +489,8 @@ utils.makeHandler = () => ({
     apply(target, ctx, args) {
       // Let's fetch the value first, to trigger and escalate potential errors
       // Illegal invocations like `navigator.__proto__.vendor` will throw here
-      const ret = utils.cache.Reflect.apply(...arguments)
-      if (args && args.length === 0) {
-        return value
-      }
-      return ret
+      ret = utils.cache.Reflect.apply(...arguments)
+      return value
     }
   })
 })


### PR DESCRIPTION
Fixes an inconsistency when an overridden getter is called via call or apply with more than zero arguments.
```js
const obj = { get foo() { return 1 } };
utils.replaceGetterWithProxy(obj, "foo", utils.makeHandler().getterValue(2));

console.log(obj.foo); // 2
console.log(Object.getOwnPropertyDescriptor(obj, "foo").get.call(obj, null)); // 1
```

Checking if `args` is truthy is redundant since it is guaranteed to be an array-like.