### PR TITLE
Use `process.once` and re-emit the kill signal after cleanup work is complete

### DIFF
--- a/packages/puppeteer-extra-plugin/src/index.ts
+++ b/packages/puppeteer-extra-plugin/src/index.ts
@@ -508,13 +508,22 @@ export abstract class PuppeteerExtraPlugin {
         browser.on('disconnected', this.onClose.bind(this))
 
         if (opts.options.handleSIGINT !== false) {
-          process.on('SIGINT', this.onClose.bind(this))
+          process.once('SIGINT', () => {
+            this.onClose()
+            process.kill(process.pid, `SIGINT`)
+          })
         }
         if (opts.options.handleSIGTERM !== false) {
-          process.on('SIGTERM', this.onClose.bind(this))
+          process.once('SIGTERM', () => {
+            this.onClose()
+            process.kill(process.pid, `SIGTERM`)
+          })
         }
         if (opts.options.handleSIGHUP !== false) {
-          process.on('SIGHUP', this.onClose.bind(this))
+          process.once('SIGHUP', () => {
+            this.onClose()
+            process.kill(process.pid, `SIGHUP`)
+          })
         }
       }
     }


### PR DESCRIPTION
Fixes #467
Co-authored-by: @Tyler-Murphy https://github.com/berstend/puppeteer-extra/issues/467#issuecomment-864191175
/cc @brunogaspar 