### PR TITLE
fix(plugin-user-data-dir): Use onDisconnect instead of onClose

### DIFF
--- a/packages/puppeteer-extra-plugin-user-data-dir/index.js
+++ b/packages/puppeteer-extra-plugin-user-data-dir/index.js
@@ -6,9 +6,7 @@ const fse = require('fs-extra')
 const os = require('os')
 const path = require('path')
 const debug = require('debug')('puppeteer-extra-plugin:user-data-dir')
-
 const mkdtempAsync = util.promisify(fs.mkdtemp)
-
 const { PuppeteerExtraPlugin } = require('puppeteer-extra-plugin')
 
 /**
@@ -108,8 +106,8 @@ class Plugin extends PuppeteerExtraPlugin {
     await this.writeFilesToProfile()
   }
 
-  async onClose() {
-    debug('onClose')
+  async onDisconnected() {
+    debug('onDisconnected')
     if (this.shouldDeleteDirectory) {
       this.deleteUserDataDir()
     }


### PR DESCRIPTION
puppeteer-extra-plugin-stealth
puppeteer-extra-plugin : user-agent-override

missing "onDisconnected" event will make application freeze
( Stuct in onClose event )

And can't use "onClose" because it's make freeze too
* **Deprecated:** Since puppeteer v1.6.0 `onDisconnected` has been improved
   * and should be used instead of `onClose`.
   *
   * In puppeteer < v1.6.0 `onDisconnected` was not catching all exit scenarios.

also relate problem has mention it on other relate problem too
pluginStealth.enabledEvasions.delete('user-agent-override'); 
this short fix, but we need "user-agent-override" to work better than disable

I test fixed by this code
```
const express = require('express'); // Adding Express
const crypto = require('crypto');
const app = express(); // Initializing Express
var bodyParser = require('body-parser');
app.use(bodyParser.urlencoded({ extended: false }));
const puppeteer = require('puppeteer-extra'); // Adding Puppeteer
const pluginStealth = require('puppeteer-extra-plugin-stealth')();
puppeteer.use(pluginStealth);

const app_dir = __dirname;

const PORT_USAGE = '8017';
var url_target = "https://google.com";
var gname = "test_session";
app.get('/', function(req, res) {
	;(async () => {
  // Launch the browser in headless mode and set up a page.
		puppeteer.launch(
		{
			args: ['--no-sandbox', '--disable-setuid-sandbox'],
			ignoreHTTPSErrors: true,
			/*executablePath: '/usr/bin/chromium-browser',*/
			dumpio: false,
			headless: true,
			userDataDir: app_dir + "/cookies_" + gname + ".cookie",
		}
		).then(async function(browser) {
			const page = await browser.newPage();
			await page.setUserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.87 Safari/537.36");
			await page.goto(url_target,{
				waitUntil: "networkidle2",
				timeout: 10 * 1000
			});

			await page.setRequestInterception(true);
			await browser.close();
			res.json({ status:process.pid })
			return res.end();

		});
})()

});
app.listen(PORT_USAGE, '127.0.0.1', function() {
	console.log(new Date().toString(),'Running on port ' + PORT_USAGE);
});
```
and request http to "127.0.0.1:8017"


It can close application without force killing