### PR TITLE
deps(plugin-devtools): Bump url-parse from 1.4.0 to 1.5.3

### DIFF
--- a/packages/puppeteer-extra-plugin-devtools/package.json
+++ b/packages/puppeteer-extra-plugin-devtools/package.json
@@ -45,7 +45,7 @@
     "ow": "^0.4.0",
     "puppeteer-extra-plugin": "^3.1.9",
     "randomstring": "^1.1.5",
-    "url-parse": "^1.4.0"
+    "url-parse": "^1.5.3"
   },
   "gitHead": "babb041828cab50c525e0b9aab02d58f73416ef3"
 }


### PR DESCRIPTION
This bumps the url-parse dependency.
