### PR TITLE
deps(plugin-user-data-dir): Bump fs-extra to v10.0.0 to avoid DeprecationWarning

### DIFF
--- a/packages/puppeteer-extra-plugin-user-data-dir/package.json
+++ b/packages/puppeteer-extra-plugin-user-data-dir/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "fs-extra": "^9.1.0",
+    "fs-extra": "^10.0.0",
     "puppeteer-extra-plugin": "^3.1.9"
   },
   "gitHead": "babb041828cab50c525e0b9aab02d58f73416ef3"


### PR DESCRIPTION
Update fs-extra to v10.0.0 to avoid deprecation warning on Node 16.x