### PR TITLE
fix(plugin-stealth): Improve iframe.contentWindow evasion

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.js
@@ -43,6 +43,10 @@ class Plugin extends PuppeteerExtraPlugin {
               if (key === 'frameElement') {
                 return iframe
               }
+              // Intercept iframe.contentWindow[0] to hide the property 0 added by the proxy.
+              if (key === '0') {
+                  return undefined
+              }
               return Reflect.get(target, key)
             }
           }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.test.js
@@ -51,6 +51,42 @@ test('stealth: will not break iframes', async t => {
   t.is(realReturn, 'TESTSTRING')
 })
 
+test('vanilla: will not have contentWindow[0]', async t => {
+  const browser = await vanillaPuppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+
+  const zero = await page.evaluate(returnValue => {
+    const { document } = window // eslint-disable-line
+    const body = document.querySelector('body')
+    const iframe = document.createElement('iframe')
+    iframe.srcdoc = 'foobar'
+    body.appendChild(iframe)
+    return typeof iframe.contentWindow[0]
+  })
+  await browser.close()
+
+  t.is(zero, 'undefined')
+})
+
+test('stealth: will not have contentWindow[0]', async t => {
+  const browser = await addExtra(vanillaPuppeteer)
+    .use(Plugin())
+    .launch({ headless: true })
+  const page = await browser.newPage()
+
+  const zero = await page.evaluate(returnValue => {
+    const { document } = window // eslint-disable-line
+    const body = document.querySelector('body')
+    const iframe = document.createElement('iframe')
+    iframe.srcdoc = 'foobar'
+    body.appendChild(iframe)
+    return typeof iframe.contentWindow[0]
+  })
+  await browser.close()
+
+  t.is(zero, 'undefined')
+})
+
 test('vanilla: will not have chrome runtine in any frame', async t => {
   const browser = await vanillaPuppeteer.launch({ headless: true })
   const page = await browser.newPage()


### PR DESCRIPTION
I think I found how Cloudflare detects puppeteer: `iframe.contentWindow[0]` returns `undefined` in Chrome and returns `window` with puppeteer (and _iframe.contentWindow_ evasion). I modify `contentWindowProxy` to returns `undefined`.

Here is a case to see the difference between Chrome and puppeteer (with _iframe.contentWindow_ evasion).

```HTML
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8">
  </head>
  <body>
    <script>
        // https://github.com/berstend/puppeteer-extra/blob/master/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.js
        const contentWindowProxy = {
            get(target, key) {
                // Now to the interesting part:
                // We actually make this thing behave like a regular iframe window,
                // by intercepting calls to e.g. `.self` and redirect it to the correct thing. :)
                // That makes it possible for these assertions to be correct:
                // iframe.contentWindow.self === window.top // must be false
                if (key === 'self') {
                    return this
                }
                // iframe.contentWindow.frameElement === iframe // must be true
                if (key === 'frameElement') {
                    return iframe
                }
                return Reflect.get(target, key)
            }
        }

        const body = document.querySelector('body')
        const iframe = document.createElement('iframe')

        const proxy = new Proxy(window, contentWindowProxy)
        Object.defineProperty(iframe, 'contentWindowStealth', {
            get() {
                return proxy
            },
            set(newValue) {
                return newValue; // contentWindow is immutable
            },
            enumerable: true,
            configurable: false
        })

        iframe.srcdoc = 'foobar'
        console.log("proxy before append iframe", proxy);
        body.appendChild(iframe)
        console.log("proxy after append iframe", proxy);

        console.log("iframe.contentWindow[0]", iframe.contentWindow[0])
        console.log("iframe.contentWindowStealth[0]", iframe.contentWindowStealth[0])
    </script>
  </body>
</html>
```

With this pull request, I no longer have the error indicated in the issue https://github.com/berstend/puppeteer-extra/issues/532#issuecomment-909472096, but puppeteer still can't pass the Cloudflare redirect.