### PR TITLE
fix: tab closed error

### DIFF
--- a/packages/puppeteer-extra-plugin/src/index.ts
+++ b/packages/puppeteer-extra-plugin/src/index.ts
@@ -534,9 +534,13 @@ export abstract class PuppeteerExtraPlugin {
     if (this.onTargetCreated) await this.onTargetCreated(target)
     // Pre filter pages for plugin developers convenience
     if (target.type() === 'page') {
-      const page = await target.page()
-      if (this.onPageCreated) {
-        await this.onPageCreated(page)
+      try {
+        const page = await target.page()
+        if (this.onPageCreated) {
+          await this.onPageCreated(page)
+        }
+      } catch (error) {
+        console.error(error)
       }
     }
   }


### PR DESCRIPTION
FIxes an error that occurs when a downloaded pdf doesn't open a new tab. See issue #546