### PR TITLE
[FIX][berstend/puppeteer-extra#556] Change to new function according to docs.

### DIFF
--- a/packages/puppeteer-extra-plugin-user-data-dir/index.js
+++ b/packages/puppeteer-extra-plugin-user-data-dir/index.js
@@ -67,7 +67,7 @@ class Plugin extends PuppeteerExtraPlugin {
     try {
       // We're doing it sync to improve chances to cleanup
       // correctly in the event of ultimate disaster.
-      fse.rmdirSync(this._userDataDir, { recursive: true })
+      fse.rmSync(this._userDataDir, { recursive: true })
     } catch (e) {
       debug(e)
     }


### PR DESCRIPTION
Just a small change, because on newer node.js versions rmDirSync etc. is deprecated.

Resolves berstend/puppeteer-extra#556