### PR TITLE
fix(plugin-stealth): Improve iframe.srcdoc evasion

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.js
@@ -79,7 +79,7 @@ class Plugin extends PuppeteerExtraPlugin {
           Object.defineProperty(iframe, 'srcdoc', {
             configurable: true, // Important, so we can reset this later
             get: function() {
-              return _iframe.srcdoc
+              return _srcdoc
             },
             set: function(newValue) {
               addContentWindowProxy(this)

--- a/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.test.js
@@ -133,6 +133,36 @@ test('vanilla: will not have chrome runtine in any frame', async t => {
   t.is(typeof srcdociframe, 'undefined')
 })
 
+test('vanilla: will return empty srcdoc by default', async t => {
+  const browser = await vanillaPuppeteer.launch({ headless: true })
+  const page = await browser.newPage()
+
+  const srcdoc = await page.evaluate(returnValue => {
+    const { document } = window // eslint-disable-line
+    const iframe = document.createElement('iframe')
+    return iframe.srcdoc
+  })
+  await browser.close()
+
+  t.is(srcdoc, '')
+})
+
+test('stealth: will return empty srcdoc by default', async t => {
+  const browser = await addExtra(vanillaPuppeteer)
+    .use(Plugin())
+    .launch({ headless: true })
+  const page = await browser.newPage()
+
+  const srcdoc = await page.evaluate(returnValue => {
+    const { document } = window // eslint-disable-line
+    const iframe = document.createElement('iframe')
+    return iframe.srcdoc
+  })
+  await browser.close()
+
+  t.is(srcdoc, '')
+})
+
 test('stealth: it will cover all frames including srcdoc', async t => {
   // const browser = await vanillaPuppeteer.launch({ headless: false })
   const browser = await addExtra(vanillaPuppeteer)


### PR DESCRIPTION
Thanks to the good analysis in the issue https://github.com/berstend/puppeteer-extra/issues/543, I fixed an infinite recursion problem when calling `iframe.srcdoc` without assigning it a value.