### PR TITLE
fix(plugin-stealth): Support generic windows UA in user-agent-override

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
@@ -136,7 +136,7 @@ class Plugin extends PuppeteerExtraPlugin {
       } else if (ua.includes('Android ')) {
         return ua.match(/Android ([^;]+)/)[1]
       } else if (ua.includes('Windows ')) {
-        return ua.match(/Windows .*?([\d|.]+);/)[1]
+        return ua.match(/Windows .*?([\d|.]+);?/)[1]
       } else {
         return ''
       }

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.test.js
@@ -260,3 +260,65 @@ test('stealth: test if UA hints are correctly set - Android 10', async t => {
     t.true(secondLoad.includes('sec-ch-ua-model: "SM-P205"'))
   }
 })
+
+async function userAgentData() {
+  if (!('userAgentData' in navigator)) {
+    return undefined
+  }
+
+  // https://wicg.github.io/ua-client-hints/#getHighEntropyValues
+  const UADataProps = ['brands', 'mobile']
+  const UADataValues = [
+    'architecture', // "arm"
+    'bitness', // "64"
+    'model', // "X644GTM"
+    'platform', // "PhoneOS"
+    'platformVersion', // "10A"
+    'uaFullVersion' // "73.32.AGX.5"
+  ]
+
+  const highEntropy = await navigator.userAgentData.getHighEntropyValues(
+    UADataValues
+  )
+
+  const result = {
+    ...highEntropy,
+    ...Object.fromEntries(UADataProps.map(k => [k, navigator.userAgentData[k]]))
+  }
+  return result
+}
+
+test('stealth: test if UA hints are correctly set - Windows 10 Generic', async t => {
+  const userAgent =
+    'Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.9999.99 Safari/537.36'
+  const locale = 'en-AU'
+
+  const puppeteer = addExtra(vanillaPuppeteer).use(
+    Plugin({
+      userAgent,
+      locale
+    })
+  )
+  const browser = await puppeteer.launch({
+    headless: true
+  })
+
+  const majorVersion = parseInt(
+    (await browser.version()).match(/\/([^\.]+)/)[1]
+  )
+  if (majorVersion < 88) {
+    t.truthy('foo')
+    console.log('Skipping test, browser version too old', majorVersion)
+    return
+  }
+  const page = await browser.newPage()
+  await page.goto('https://example.com') // secure context
+
+  const results = await page.evaluate(userAgentData)
+  t.is(results.platform, 'Windows')
+  t.is(results.platformVersion, '10.0')
+  t.is(results.uaFullVersion, '99.0.9999.99')
+
+  const language = await page.evaluate(() => navigator.language)
+  t.is(language, locale)
+})

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.test.js
@@ -306,7 +306,7 @@ test('stealth: test if UA hints are correctly set - Windows 10 Generic', async t
   const majorVersion = parseInt(
     (await browser.version()).match(/\/([^\.]+)/)[1]
   )
-  if (majorVersion < 88) {
+  if (majorVersion < 90) {
     t.truthy('foo')
     console.log('Skipping test, browser version too old', majorVersion)
     return

--- a/packages/puppeteer-extra-plugin-stealth/package.json
+++ b/packages/puppeteer-extra-plugin-stealth/package.json
@@ -48,7 +48,7 @@
     "fpscanner": "^0.1.5",
     "loop": "^3.0.6",
     "npm-run-all": "^4.1.5",
-    "puppeteer": "^2.0.0"
+    "puppeteer": "9"
   },
   "dependencies": {
     "debug": "^4.1.1",


### PR DESCRIPTION
This PR updates the regex used in the `user-agent-override` evasion to support generic Windows UAs (e.g. `Mozilla/5.0 (Windows NT 10.0)`).

It supersedes #554 by @jpxzp (no tests), and #440 by @nguyen930411 (PR got messed up with unrelated commits).

Fixes #553 #492