### PR TITLE
fix(plugin-user-data-dir): Use new fs.rmSync when available

### DIFF
--- a/packages/puppeteer-extra-plugin-user-data-dir/index.js
+++ b/packages/puppeteer-extra-plugin-user-data-dir/index.js
@@ -63,11 +63,24 @@ class Plugin extends PuppeteerExtraPlugin {
   }
 
   deleteUserDataDir() {
-    debug('removeUserDataDir')
+    debug('removeUserDataDir', this._userDataDir)
     try {
       // We're doing it sync to improve chances to cleanup
       // correctly in the event of ultimate disaster.
-      fse.rmdirSync(this._userDataDir, { recursive: true })
+      if ('rmSync' in fs) {
+        // Only available in node >= v14.14.0
+        fs.rmSync(this._userDataDir, {
+          recursive: true,
+          force: true, // exceptions will be ignored if path does not exist
+          maxRetries: 3
+        })
+      } else {
+        // Deprecated since node >= v14.14.0
+        fs.rmdirSync(this._userDataDir, {
+          recursive: true,
+          maxRetries: 3
+        })
+      }
     } catch (e) {
       debug(e)
     }


### PR DESCRIPTION
`fs.rmdirSync` is deprecated since node >= v14.14.0, this PR supports using the new `fs.rmSync` when available (node >= v14.14.0)

Fixes #556