### PR TITLE
fix(plugin-devtools): Support headless again by modifying index page

### DIFF
--- a/packages/puppeteer-extra-plugin-devtools/lib/RemoteDevTools.js
+++ b/packages/puppeteer-extra-plugin-devtools/lib/RemoteDevTools.js
@@ -188,6 +188,14 @@ class DevToolsTunnel extends DevToolsCommon {
       return
     }
     body = body.replace(`fetch(url).`, `fetch(url, {credentials: 'include'}).`)
+
+    // Fix for headless index pages that use weird client-side JS to modify the devtoolsFrontendUrl to something not working for us
+    // https://github.com/berstend/puppeteer-extra/issues/566
+    body = body.replace(
+      'link.href = `https://chrome-devtools-frontend.appspot.com',
+      'link.href = item.devtoolsFrontendUrl; // '
+    )
+
     debug('fetch:after', body)
     return body
   }

--- a/packages/puppeteer-extra-plugin-devtools/package.json
+++ b/packages/puppeteer-extra-plugin-devtools/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "docs": "node -e 0",
     "lint": "eslint --ext .js .",
-    "test-old": "ava --fail-fast -v",
-    "test": "run-p lint",
+    "test-ava": "ava --fail-fast -v",
+    "test": "run-p lint test-ava",
     "test-ci": "run-s test"
   },
   "engines": {

--- a/packages/puppeteer-extra-plugin-devtools/readme.md
+++ b/packages/puppeteer-extra-plugin-devtools/readme.md
@@ -12,10 +12,10 @@ yarn add puppeteer-extra-plugin-devtools
 
 **Make puppeteer browser debugging possible from anywhere.**
 
--   Creates a secure tunnel to make the devtools frontend (**incl. screencasting**) accessible from the public internet
--   Works for both headless and headful puppeteer instances, as well as within docker containers
--   Uses the already existing DevTools Protocol websocket connection from puppeteer
--   Features some convenience functions for using the devtools frontend locally
+- Creates a secure tunnel to make the devtools frontend (**incl. screencasting**) accessible from the public internet
+- Works for both headless and headful puppeteer instances, as well as within docker containers
+- Uses the already existing DevTools Protocol websocket connection from puppeteer
+- Features some convenience functions for using the devtools frontend locally
 
 ## Magic
 
@@ -28,15 +28,17 @@ const puppeteer = require('puppeteer-extra')
 const devtools = require('puppeteer-extra-plugin-devtools')()
 puppeteer.use(devtools)
 
-puppeteer.launch().then(async browser => {
-  const tunnel = await devtools.createTunnel(browser)
-  console.log(tunnel.url) // => https://devtools-tunnel-sdoqqj95vg.localtunnel.me
+puppeteer
+  .launch({ headless: true, defaultViewport: null })
+  .then(async browser => {
+    console.log('Start')
+    const tunnel = await devtools.createTunnel(browser)
+    console.log(tunnel.url)
 
-  const page = await browser.newPage()
-  await page.goto('https://www.google.com')
-  await page.waitForTimeout(60 * 1000)
-  browser.close()
-})
+    const page = await browser.newPage()
+    await page.goto('https://example.com')
+    console.log('All setup.')
+  })
 ```
 
 ## API
@@ -45,14 +47,14 @@ puppeteer.launch().then(async browser => {
 
 #### Table of Contents
 
--   [Plugin](#plugin)
-    -   [createTunnel](#createtunnel)
-    -   [setAuthCredentials](#setauthcredentials)
-    -   [getLocalDevToolsUrl](#getlocaldevtoolsurl)
--   [Tunnel](#tunnel)
-    -   [url](#url)
-    -   [getUrlForPage](#geturlforpage)
-    -   [close](#close)
+- [Plugin](#plugin)
+  - [createTunnel](#createtunnel)
+  - [setAuthCredentials](#setauthcredentials)
+  - [getLocalDevToolsUrl](#getlocaldevtoolsurl)
+- [Tunnel](#tunnel)
+  - [url](#url)
+  - [getUrlForPage](#geturlforpage)
+  - [close](#close)
 
 ### [Plugin](https://github.com/berstend/puppeteer-extra/blob/db57ea66cf10d407cf63af387892492e495a84f2/packages/puppeteer-extra-plugin-devtools/index.js#L34-L168)
 
@@ -69,12 +71,12 @@ generate a password and print it to STDOUT.
 
 Type: `function (opts)`
 
--   `opts` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Options (optional, default `{}`)
-    -   `opts.auth` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Basic auth credentials for the public page
-        -   `opts.auth.user` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Username (default: 'user')
-        -   `opts.auth.pass` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Password (will be generated if not provided)
-    -   `opts.prefix` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** The prefix to use for the localtunnel.me subdomain (default: 'devtools-tunnel')
-    -   `opts.localtunnel` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Advanced options to pass to [localtunnel](https://github.com/localtunnel/localtunnel#options)
+- `opts` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Options (optional, default `{}`)
+  - `opts.auth` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Basic auth credentials for the public page
+    - `opts.auth.user` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Username (default: 'user')
+    - `opts.auth.pass` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Password (will be generated if not provided)
+  - `opts.prefix` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** The prefix to use for the localtunnel.me subdomain (default: 'devtools-tunnel')
+  - `opts.localtunnel` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Advanced options to pass to [localtunnel](https://github.com/localtunnel/localtunnel#options)
 
 Example:
 
@@ -91,7 +93,7 @@ puppeteer.launch().then(async browser => {
 })
 ```
 
-* * *
+---
 
 #### [createTunnel](https://github.com/berstend/puppeteer-extra/blob/db57ea66cf10d407cf63af387892492e495a84f2/packages/puppeteer-extra-plugin-devtools/index.js#L82-L93)
 
@@ -101,7 +103,7 @@ Supports multiple browser instances (will create a new tunnel for each).
 
 Type: `function (browser): Tunnel`
 
--   `browser` **Puppeteer.Browser** The browser to create the tunnel for (there can be multiple)
+- `browser` **Puppeteer.Browser** The browser to create the tunnel for (there can be multiple)
 
 Example:
 
@@ -110,13 +112,12 @@ const puppeteer = require('puppeteer-extra')
 const devtools = require('puppeteer-extra-plugin-devtools')()
 devtools.setAuthCredentials('bob', 'swordfish')
 puppeteer.use(devtools)
-
 ;(async () => {
   const browserFleet = await Promise.all(
     [...Array(3)].map(slot => puppeteer.launch())
   )
   for (const [index, browser] of browserFleet.entries()) {
-    const {url} = await devtools.createTunnel(browser)
+    const { url } = await devtools.createTunnel(browser)
     console.info(`Browser ${index}'s devtools frontend can be found at: ${url}`)
   }
 })()
@@ -126,7 +127,7 @@ puppeteer.use(devtools)
 // Browser 2's devtools frontend can be found at: https://devtools-tunnel-pp83sdi4jo.localtunnel.me
 ```
 
-* * *
+---
 
 #### [setAuthCredentials](https://github.com/berstend/puppeteer-extra/blob/db57ea66cf10d407cf63af387892492e495a84f2/packages/puppeteer-extra-plugin-devtools/index.js#L113-L119)
 
@@ -136,8 +137,8 @@ Alternatively the credentials can be defined when instantiating the plugin.
 
 Type: `function (user, pass)`
 
--   `user` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Username
--   `pass` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Password
+- `user` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Username
+- `pass` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Password
 
 Example:
 
@@ -152,7 +153,7 @@ puppeteer.launch().then(async browser => {
 })
 ```
 
-* * *
+---
 
 #### [getLocalDevToolsUrl](https://github.com/berstend/puppeteer-extra/blob/db57ea66cf10d407cf63af387892492e495a84f2/packages/puppeteer-extra-plugin-devtools/index.js#L137-L142)
 
@@ -160,7 +161,7 @@ Convenience function to get the local devtools frontend URL.
 
 Type: `function (browser): string`
 
--   `browser` **Puppeteer.Browser** 
+- `browser` **Puppeteer.Browser**
 
 Example:
 
@@ -175,7 +176,7 @@ puppeteer.launch().then(async browser => {
 })
 ```
 
-* * *
+---
 
 ### [Tunnel](https://github.com/berstend/puppeteer-extra/blob/db57ea66cf10d407cf63af387892492e495a84f2/packages/puppeteer-extra-plugin-devtools/index.js#L174-L217)
 
@@ -185,10 +186,10 @@ The devtools tunnel for a browser instance.
 
 Type: `function (wsEndpoint, opts)`
 
--   `wsEndpoint`  
--   `opts`   (optional, default `{}`)
+- `wsEndpoint`
+- `opts` (optional, default `{}`)
 
-* * *
+---
 
 #### [url](https://github.com/berstend/puppeteer-extra/blob/db57ea66cf10d407cf63af387892492e495a84f2/packages/puppeteer-extra-plugin-devtools/index.js#L187-L187)
 
@@ -204,7 +205,7 @@ console.log(tunnel.url)
 // => https://devtools-tunnel-sdoqqj95vg.localtunnel.me
 ```
 
-* * *
+---
 
 #### [getUrlForPage](https://github.com/berstend/puppeteer-extra/blob/db57ea66cf10d407cf63af387892492e495a84f2/packages/puppeteer-extra-plugin-devtools/index.js#L201-L205)
 
@@ -212,7 +213,7 @@ Get the devtools frontend deep link for a specific page.
 
 Type: `function (page): string`
 
--   `page` **Puppeteer.Page** 
+- `page` **Puppeteer.Page**
 
 Example:
 
@@ -223,7 +224,7 @@ console.log(tunnel.getUrlForPage(page))
 // => https://devtools-tunnel-bmkjg26zmr.localtunnel.me/devtools/inspector.html?ws(...)
 ```
 
-* * *
+---
 
 #### [close](https://github.com/berstend/puppeteer-extra/blob/db57ea66cf10d407cf63af387892492e495a84f2/packages/puppeteer-extra-plugin-devtools/index.js#L216-L216)
 
@@ -240,4 +241,4 @@ const tunnel = await devtools.createTunnel(browser)
 tunnel.close()
 ```
 
-* * *
+---

--- a/packages/puppeteer-extra-plugin-devtools/test/headless.js
+++ b/packages/puppeteer-extra-plugin-devtools/test/headless.js
@@ -19,26 +19,26 @@ test('will create a tunnel', async t => {
   await puppeteer.launch({ args: PUPPETEER_ARGS }).then(async browser => {
     const tunnel = await devtools.createTunnel(browser)
     t.true(tunnel.url.includes('https://devtools-tunnel-'))
-    t.true(tunnel.url.includes('.localtunnel.me'))
-    browser.close()
+    await browser.close()
   })
   t.true(true)
 })
 
-test('will create a tunnel with custom localtunnel options', async t => {
-  const puppeteer = require('puppeteer-extra')
-  const devtools = require('puppeteer-extra-plugin-devtools')({
-    auth: { user: 'francis', pass: 'president' },
-    localtunnel: {
-      host: 'https://tunnel.datahub.at'
-    }
-  })
-  puppeteer.use(devtools)
+// Note: https://tunnel.datahub.at is gone and I don't have an alternative currently
+// test('will create a tunnel with custom localtunnel options', async t => {
+//   const puppeteer = require('puppeteer-extra')
+//   const devtools = require('puppeteer-extra-plugin-devtools')({
+//     auth: { user: 'francis', pass: 'president' },
+//     localtunnel: {
+//       host: 'https://tunnel.datahub.at'
+//     }
+//   })
+//   puppeteer.use(devtools)
 
-  await puppeteer.launch({ args: PUPPETEER_ARGS }).then(async browser => {
-    const tunnel = await devtools.createTunnel(browser)
-    t.true(tunnel.url.includes('.tunnel.datahub.at'))
-    browser.close()
-  })
-  t.true(true)
-})
+//   await puppeteer.launch({ args: PUPPETEER_ARGS }).then(async browser => {
+//     const tunnel = await devtools.createTunnel(browser)
+//     t.true(tunnel.url.includes('.tunnel.datahub.at'))
+//     browser.close()
+//   })
+//   t.true(true)
+// })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2559,11 +2559,6 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
-at-least-node@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
-  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
-
 atob-lite@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/atob-lite/-/atob-lite-2.0.0.tgz#0fef5ad46f1bd7a8502c65727f0367d5ee43d696"
@@ -4927,6 +4922,15 @@ fs-extra@8.1.0, fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
+  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
@@ -4935,16 +4939,6 @@ fs-extra@^7.0.0:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
-
-fs-extra@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
-  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
-  dependencies:
-    at-least-node "^1.0.0"
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
 
 fs-minipass@^1.2.7:
   version "1.2.7"
@@ -10684,7 +10678,7 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@^1.4.0:
+url-parse@^1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.3.tgz#71c1303d38fb6639ade183c2992c8cc0686df862"
   integrity sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==


### PR DESCRIPTION
The devtools index page ("Select target to inspect") differs between headful and headless browser instances, the latter now started to client-side modify the devtoolsFrontendUrl to something that breaks the [devtools plugin](https://github.com/berstend/puppeteer-extra/tree/master/packages/puppeteer-extra-plugin-devtools) functionality - this PR fixes this.

In addition we re-enable CI testing of the devtools plugin.

Thanks to @abowcut for reporting and investigating this issue, fixes #566, #249