### PR TITLE
fix(plugin-devtools): Add localtunnel error event

### DIFF
--- a/packages/puppeteer-extra-plugin-devtools/lib/RemoteDevTools.js
+++ b/packages/puppeteer-extra-plugin-devtools/lib/RemoteDevTools.js
@@ -264,7 +264,7 @@ class DevToolsTunnel extends DevToolsCommon {
       debug('tunnel:close')
     })
 
-    tunnel.on('error', (err) => {
+    tunnel.on('error', err => {
       console.log('tunnel error', err)
     })
 

--- a/packages/puppeteer-extra-plugin-devtools/lib/RemoteDevTools.js
+++ b/packages/puppeteer-extra-plugin-devtools/lib/RemoteDevTools.js
@@ -265,7 +265,7 @@ class DevToolsTunnel extends DevToolsCommon {
     })
 
     tunnel.on('error', (err) => {
-      debug('tunnel errored', err)
+      console.log('tunnel error', err);
     })
 
     debug('tunnel:created', tunnel.url)

--- a/packages/puppeteer-extra-plugin-devtools/lib/RemoteDevTools.js
+++ b/packages/puppeteer-extra-plugin-devtools/lib/RemoteDevTools.js
@@ -264,6 +264,10 @@ class DevToolsTunnel extends DevToolsCommon {
       debug('tunnel:close')
     })
 
+    tunnel.on('error', (err) => {
+      debug('tunnel errored', err)
+    })
+
     debug('tunnel:created', tunnel.url)
     return tunnel
   }

--- a/packages/puppeteer-extra-plugin-devtools/lib/RemoteDevTools.js
+++ b/packages/puppeteer-extra-plugin-devtools/lib/RemoteDevTools.js
@@ -265,7 +265,7 @@ class DevToolsTunnel extends DevToolsCommon {
     })
 
     tunnel.on('error', (err) => {
-      console.log('tunnel error', err);
+      console.log('tunnel error', err)
     })
 
     debug('tunnel:created', tunnel.url)


### PR DESCRIPTION
As mentioned on many [issues](https://github.com/localtunnel/localtunnel/issues/258) on the localtunnel [github](https://github.com/localtunnel/localtunnel), using the public localtunnel server leads to crashes quite frequently as the public server becomes overloaded many times throughout the day.

Currently, when using the devtools plugin, if the public localtunnel server is having one of its "episodes" and the connection refused error is thrown the entire node process that puppeteer is running in crashes.

This pull request simply adds a listener to the tunnel for the error event and handles it so that even though the cdp might not be working for that browser at least the node process can continue to run.
To me this is definitely preferable over having the whole node process running puppeteer exit.
