### PR TITLE
docs(puppeteer-extra): Remove types notice, add community plugin

### DIFF
--- a/packages/puppeteer-extra/readme.md
+++ b/packages/puppeteer-extra/readme.md
@@ -350,6 +350,11 @@ _Please note that they're hosted outside the main project and not under our cont
 - Minimize and maximize puppeteer in real time.
 - Great for manually solving captchas.
 
+#### [`puppeteer-extra-plugin-portal`](https://github.com/claabs/puppeteer-extra-plugin-portal)
+
+- Use the Chromium screencast API to remotely view and interact with puppeteer sessions.
+- Great for remotely intervening when an automated task gets stuck, like captchas.
+
 > Please check the `Contributing` section below if you're interested in creating a plugin as well.
 
 ---

--- a/packages/puppeteer-extra/readme.md
+++ b/packages/puppeteer-extra/readme.md
@@ -70,8 +70,6 @@ DEBUG=puppeteer-extra,puppeteer-extra-plugin:* node myscript.js
 <details>
  <summary><strong>TypeScript usage</strong></summary><br/>
 
-**NOTE: `puppeteer` broke typings in recent versions, please install `puppeteer@5` for the time being (see [here](https://github.com/berstend/puppeteer-extra/issues/428#issuecomment-778679665) for more info).**
-
 > `puppeteer-extra` and most plugins are written in TS,
 > so you get perfect type support out of the box. :)
 


### PR DESCRIPTION
- Adds my plugin [puppeteer-extra-plugin-portal](https://github.com/claabs/puppeteer-extra-plugin-portal) to the community plugins section. I finally released it, so I figured I may as well add it to the list.
- Remove the puppeteer version notice for types now that #428 is closed