### PR TITLE
feat(plugin-recaptcha): Add proxy support

### DIFF
--- a/packages/puppeteer-extra-plugin-recaptcha/readme.md
+++ b/packages/puppeteer-extra-plugin-recaptcha/readme.md
@@ -140,6 +140,9 @@ If you'd like to see debug output just run your script like so:
 DEBUG=puppeteer-extra,puppeteer-extra-plugin:* node myscript.js
 ```
 
+### Proxies
+If you want to attach a proxy while running a bypass, set the enviroment variables ``2CAPTCHA_PROXY_TYPE`` and ``2CAPTCHA_PROXY_ADDRESS``
+
 _**Tip:** The recaptcha plugin works really well together with the [stealth plugin](https://github.com/berstend/puppeteer-extra/tree/master/packages/puppeteer-extra-plugin-stealth)._
 
 ## Motivation 🏴

--- a/packages/puppeteer-extra-plugin-recaptcha/src/provider/2captcha.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/provider/2captcha.ts
@@ -89,6 +89,12 @@ async function getSolution(
     if (opts.useEnterpriseFlag && captcha.isEnterprise) {
       extraData['enterprise'] = 1
     }
+    
+    if (process.env['2CAPTCHA_PROXY_TYPE'] && process.env['2CAPTCHA_PROXY_ADDRESS']) {
+         extraData['proxytype'] = process.env['2CAPTCHA_PROXY_TYPE'].toUpperCase()
+         extraData['proxy'] = process.env['2CAPTCHA_PROXY_ADDRESS']
+    }
+      
     const { err, result, invalid } = await decodeRecaptchaAsync(
       token,
       captcha._vendor,


### PR DESCRIPTION
This pull request adds support for using proxies in puppeteer-extra. The docs for 2captcha proxies is [here](https://2captcha.com/2captcha-api#proxies). 

To use proxies all you need to do is set two environment variables (``2CAPTCHA_PROXY_TYPE`` and ``2CAPTCHA_PROXY_ADDRESS``) and the program will add the extra options when sending the request to 2captcha.

This will help bypass detection.

@berstend 