### PR TITLE
feat(plugin-adblocker): Add cooperative intercept mode support

### DIFF
--- a/packages/puppeteer-extra-plugin-adblocker/package.json
+++ b/packages/puppeteer-extra-plugin-adblocker/package.json
@@ -61,7 +61,7 @@
     "typescript": "4.1.2"
   },
   "dependencies": {
-    "@cliqz/adblocker-puppeteer": "1.23.1",
+    "@cliqz/adblocker-puppeteer": "1.23.2",
     "debug": "^4.1.1",
     "node-fetch": "^2.6.0",
     "puppeteer-extra-plugin": "^3.2.0"

--- a/packages/puppeteer-extra-plugin-adblocker/package.json
+++ b/packages/puppeteer-extra-plugin-adblocker/package.json
@@ -47,7 +47,7 @@
     "@types/puppeteer": "*",
     "ava": "^2.4.0",
     "npm-run-all": "^4.1.5",
-    "puppeteer": "^8.0.0",
+    "puppeteer": "^10.2.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.27.5",
     "rollup-plugin-commonjs": "^10.1.0",
@@ -61,7 +61,7 @@
     "typescript": "4.1.2"
   },
   "dependencies": {
-    "@cliqz/adblocker-puppeteer": "1.23.0",
+    "@cliqz/adblocker-puppeteer": "1.23.1",
     "debug": "^4.1.1",
     "node-fetch": "^2.6.0",
     "puppeteer-extra-plugin": "^3.2.0"

--- a/packages/puppeteer-extra-plugin-adblocker/package.json
+++ b/packages/puppeteer-extra-plugin-adblocker/package.json
@@ -61,7 +61,7 @@
     "typescript": "4.1.2"
   },
   "dependencies": {
-    "@cliqz/adblocker-puppeteer": "1.22.6",
+    "@cliqz/adblocker-puppeteer": "1.23.0",
     "debug": "^4.1.1",
     "node-fetch": "^2.6.0",
     "puppeteer-extra-plugin": "^3.2.0"

--- a/packages/puppeteer-extra-plugin-adblocker/readme.md
+++ b/packages/puppeteer-extra-plugin-adblocker/readme.md
@@ -39,7 +39,10 @@ const puppeteer = require('puppeteer-extra')
 // Add adblocker plugin, which will transparently block ads in all pages you
 // create using puppeteer.
 const AdblockerPlugin = require('puppeteer-extra-plugin-adblocker')
-puppeteer.use(AdblockerPlugin())
+puppeteer.use(AdblockerPlugin({
+  // Optionally enable Cooperative Mode for several request interceptors
+  interceptResolutionPriority: 0
+}))
 
 // puppeteer usage as normal
 puppeteer.launch({ headless: true }).then(async (browser) => {

--- a/packages/puppeteer-extra-plugin-adblocker/readme.md
+++ b/packages/puppeteer-extra-plugin-adblocker/readme.md
@@ -38,10 +38,11 @@ const puppeteer = require('puppeteer-extra')
 
 // Add adblocker plugin, which will transparently block ads in all pages you
 // create using puppeteer.
+const { DEFAULT_INTERCEPT_RESOLUTION_PRIORITY } = require('puppeteer')
 const AdblockerPlugin = require('puppeteer-extra-plugin-adblocker')
 puppeteer.use(AdblockerPlugin({
   // Optionally enable Cooperative Mode for several request interceptors
-  interceptResolutionPriority: 0
+  interceptResolutionPriority: DEFAULT_INTERCEPT_RESOLUTION_PRIORITY
 }))
 
 // puppeteer usage as normal

--- a/packages/puppeteer-extra-plugin-adblocker/src/index.ts
+++ b/packages/puppeteer-extra-plugin-adblocker/src/index.ts
@@ -115,7 +115,7 @@ export class PuppeteerExtraPluginAdblocker extends PuppeteerExtraPlugin {
   /**
    * Sets the request interception priority on the `PuppeteerBlocker` instance.
    */
-   private setRequestInterceptionPriority(): void {
+  private setRequestInterceptionPriority(): void {
     this.blocker?.setRequestInterceptionPriority(this.opts.interceptResolutionPriority)
   }
 

--- a/packages/puppeteer-extra-plugin-adblocker/src/index.ts
+++ b/packages/puppeteer-extra-plugin-adblocker/src/index.ts
@@ -17,6 +17,8 @@ export interface PluginOptions {
   useCache: boolean
   /** Optional custom directory for adblocker cache files. Default: undefined */
   cacheDir?: string
+  /** Optional custom priority for interception resolution. Default: 0 */
+  interceptResolutionPriority?: number
 }
 
 /**
@@ -38,7 +40,8 @@ export class PuppeteerExtraPluginAdblocker extends PuppeteerExtraPlugin {
     return {
       blockTrackers: false,
       useCache: true,
-      cacheDir: undefined
+      cacheDir: undefined,
+      interceptResolutionPriority: 0
     }
   }
 
@@ -99,8 +102,10 @@ export class PuppeteerExtraPluginAdblocker extends PuppeteerExtraPlugin {
     if (this.blocker === undefined) {
       try {
         this.blocker = await this.loadFromCache()
+        this.blocker.setRequestInterceptionPriority(this.opts.interceptResolutionPriority)
       } catch (ex) {
         this.blocker = await this.loadFromRemote()
+        this.blocker.setRequestInterceptionPriority(this.opts.interceptResolutionPriority)
         await this.persistToCache(this.blocker)
       }
     }

--- a/packages/puppeteer-extra-plugin-adblocker/src/index.ts
+++ b/packages/puppeteer-extra-plugin-adblocker/src/index.ts
@@ -17,7 +17,7 @@ export interface PluginOptions {
   useCache: boolean
   /** Optional custom directory for adblocker cache files. Default: undefined */
   cacheDir?: string
-  /** Optional custom priority for interception resolution. Default: 0 */
+  /** Optional custom priority for interception resolution. Default: undefined */
   interceptResolutionPriority?: number
 }
 
@@ -41,7 +41,7 @@ export class PuppeteerExtraPluginAdblocker extends PuppeteerExtraPlugin {
       blockTrackers: false,
       useCache: true,
       cacheDir: undefined,
-      interceptResolutionPriority: 0
+      interceptResolutionPriority: undefined
     }
   }
 
@@ -102,14 +102,21 @@ export class PuppeteerExtraPluginAdblocker extends PuppeteerExtraPlugin {
     if (this.blocker === undefined) {
       try {
         this.blocker = await this.loadFromCache()
-        this.blocker.setRequestInterceptionPriority(this.opts.interceptResolutionPriority)
+        this.setRequestInterceptionPriority()
       } catch (ex) {
         this.blocker = await this.loadFromRemote()
-        this.blocker.setRequestInterceptionPriority(this.opts.interceptResolutionPriority)
+        this.setRequestInterceptionPriority()
         await this.persistToCache(this.blocker)
       }
     }
     return this.blocker
+  }
+
+  /**
+   * Sets the request interception priority on the `PuppeteerBlocker` instance.
+   */
+   private setRequestInterceptionPriority(): void {
+    this.blocker?.setRequestInterceptionPriority(this.opts.interceptResolutionPriority)
   }
 
   /**

--- a/packages/puppeteer-extra-plugin-block-resources/example.js
+++ b/packages/puppeteer-extra-plugin-block-resources/example.js
@@ -16,11 +16,13 @@
 //   console.log('all done')
 // })()
 
+const { DEFAULT_INTERCEPT_RESOLUTION_PRIORITY } = require('puppeteer')
 const puppeteer = require('puppeteer-extra')
 const blockResourcesPlugin = require('puppeteer-extra-plugin-block-resources')({
   // Optionally enable Cooperative Mode for several request interceptors
-  interceptResolutionPriority: 0
+  interceptResolutionPriority: DEFAULT_INTERCEPT_RESOLUTION_PRIORITY
 })
+
 puppeteer.use(blockResourcesPlugin)
 ;(async () => {
   const browser = await puppeteer.launch({ headless: false })

--- a/packages/puppeteer-extra-plugin-block-resources/example.js
+++ b/packages/puppeteer-extra-plugin-block-resources/example.js
@@ -17,7 +17,10 @@
 // })()
 
 const puppeteer = require('puppeteer-extra')
-const blockResourcesPlugin = require('puppeteer-extra-plugin-block-resources')()
+const blockResourcesPlugin = require('puppeteer-extra-plugin-block-resources')({
+  // Optionally enable Cooperative Mode for several request interceptors
+  interceptResolutionPriority: 0
+})
 puppeteer.use(blockResourcesPlugin)
 ;(async () => {
   const browser = await puppeteer.launch({ headless: false })

--- a/packages/puppeteer-extra-plugin-block-resources/index.d.ts
+++ b/packages/puppeteer-extra-plugin-block-resources/index.d.ts
@@ -1,0 +1,22 @@
+import { PuppeteerExtraPlugin } from 'puppeteer-extra-plugin'
+import { ResourceType } from 'puppeteer'
+
+declare interface PluginOptions {
+  availableTypes?: Set<ResourceType>
+  blockedTypes?: Set<ResourceType>
+  interceptResolutionPriority?: number
+}
+
+declare class Plugin extends PuppeteerExtraPlugin {
+  constructor(opts: Partial<PluginOptions>)
+  get name(): string
+  get defaults(): PluginOptions
+  get engineCacheFile(): string
+  get availableTypes(): Set<ResourceType>
+  get blockedTypes(): Set<ResourceType>
+  get interceptResolutionPriority(): number
+}
+
+declare const _default: (options?: Partial<PluginOptions>) => Plugin
+
+export default _default

--- a/packages/puppeteer-extra-plugin-block-resources/index.js
+++ b/packages/puppeteer-extra-plugin-block-resources/index.js
@@ -112,15 +112,7 @@ class Plugin extends PuppeteerExtraPlugin {
     const type = request.resourceType()
     const shouldBlock = this.blockedTypes.has(type)
 
-    // Check support for Cooperative Intercept Mode
-    const [
-      currentResolution,
-      currentPriority
-    ] = request.interceptResolutionState
-      ? request.interceptResolutionState()
-      : []
-
-    // Requests are immediately handled in Legacy Mode
+    // Requests are immediately handled if not using Cooperative Intercept Mode
     const alreadyHandled = request.isInterceptResolutionHandled
       ? request.isInterceptResolutionHandled()
       : true
@@ -128,8 +120,7 @@ class Plugin extends PuppeteerExtraPlugin {
     this.debug('onRequest', {
       type,
       shouldBlock,
-      currentResolution,
-      currentPriority
+      alreadyHandled
     })
 
     if (alreadyHandled) return

--- a/packages/puppeteer-extra-plugin-block-resources/index.js
+++ b/packages/puppeteer-extra-plugin-block-resources/index.js
@@ -112,7 +112,7 @@ class Plugin extends PuppeteerExtraPlugin {
     const type = request.resourceType()
     const shouldBlock = this.blockedTypes.has(type)
 
-    // Cooperative Intercept Mode only available in puppeteer@11+
+    // Cooperative Intercept Mode only available in puppeteer@10.2+
     const [currentResolution, currentPriority] = request.interceptResolution
       ? request.interceptResolution()
       : []

--- a/packages/puppeteer-extra-plugin-block-resources/index.js
+++ b/packages/puppeteer-extra-plugin-block-resources/index.js
@@ -112,15 +112,17 @@ class Plugin extends PuppeteerExtraPlugin {
     const type = request.resourceType()
     const shouldBlock = this.blockedTypes.has(type)
 
-    // Cooperative Intercept Mode only available in puppeteer@10.2+
-    const [currentResolution, currentPriority] = request.interceptResolution
-      ? request.interceptResolution()
+    // Check support for Cooperative Intercept Mode
+    const [
+      currentResolution,
+      currentPriority
+    ] = request.interceptResolutionState
+      ? request.interceptResolutionState()
       : []
 
-    // Avoid using resolution `alreay-handled` with typo
     // Requests are immediately handled in Legacy Mode
-    const alreadyHandled = currentResolution
-      ? currentResolution.endsWith('handled')
+    const alreadyHandled = request.isInterceptResolutionHandled
+      ? request.isInterceptResolutionHandled()
       : true
 
     this.debug('onRequest', {

--- a/packages/puppeteer-extra-plugin-block-resources/index.js
+++ b/packages/puppeteer-extra-plugin-block-resources/index.js
@@ -11,10 +11,11 @@ const { PuppeteerExtraPlugin } = require('puppeteer-extra-plugin')
  * @param {Set<string>} [opts.blockedTypes] - Specify which resourceTypes to block (by default none)
  *
  * @example
+ * const { DEFAULT_INTERCEPT_RESOLUTION_PRIORITY } = require('puppeteer')
  * puppeteer.use(require('puppeteer-extra-plugin-block-resources')({
  *   blockedTypes: new Set(['image', 'stylesheet']),
  *   // Optionally enable Cooperative Mode for several request interceptors
- *   interceptResolutionPriority: 0
+ *   interceptResolutionPriority: DEFAULT_INTERCEPT_RESOLUTION_PRIORITY
  * }))
  *
  * //
@@ -126,7 +127,7 @@ class Plugin extends PuppeteerExtraPlugin {
     if (alreadyHandled) return
 
     if (shouldBlock) {
-      const abortArgs = request.continueRequestOverrides
+      const abortArgs = request.abortErrorReason
         ? ['blockedbyclient', this.interceptResolutionPriority]
         : []
 

--- a/packages/puppeteer-extra-plugin-block-resources/index.test.js
+++ b/packages/puppeteer-extra-plugin-block-resources/index.test.js
@@ -26,14 +26,15 @@ test('should have the public child class members', async t => {
   t.true(childClassMembers.includes('defaults'))
   t.true(childClassMembers.includes('availableTypes'))
   t.true(childClassMembers.includes('blockedTypes'))
-  t.true(childClassMembers.includes('blockedTypes'))
+  t.true(childClassMembers.includes('interceptResolutionPriority'))
   t.true(childClassMembers.includes('onRequest'))
   t.true(childClassMembers.includes('onPageCreated'))
-  t.true(childClassMembers.length === 7)
+  t.true(childClassMembers.length === 8)
 })
 
 test('should have opts with default values', async t => {
   const instance = new Plugin()
   t.deepEqual(instance.opts.blockedTypes, new Set([]))
   t.is(instance.opts.availableTypes.size, 13)
+  t.is(instance.opts.interceptResolutionPriority, 0)
 })

--- a/packages/puppeteer-extra-plugin-block-resources/index.test.js
+++ b/packages/puppeteer-extra-plugin-block-resources/index.test.js
@@ -36,5 +36,5 @@ test('should have opts with default values', async t => {
   const instance = new Plugin()
   t.deepEqual(instance.opts.blockedTypes, new Set([]))
   t.is(instance.opts.availableTypes.size, 13)
-  t.is(instance.opts.interceptResolutionPriority, 0)
+  t.is(instance.opts.interceptResolutionPriority, undefined)
 })

--- a/packages/puppeteer-extra-plugin-block-resources/package.json
+++ b/packages/puppeteer-extra-plugin-block-resources/package.json
@@ -3,6 +3,7 @@
   "version": "2.3.0",
   "description": "Block resources (images, media, etc.) in puppeteer.",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": "berstend/puppeteer-extra",
   "author": "berstend",
   "license": "MIT",

--- a/packages/puppeteer-extra-plugin-block-resources/readme.md
+++ b/packages/puppeteer-extra-plugin-block-resources/readme.md
@@ -35,7 +35,9 @@ Example:
 
 ```javascript
 puppeteer.use(require('puppeteer-extra-plugin-block-resources')({
-  blockedTypes: new Set(['image', 'stylesheet'])
+  blockedTypes: new Set(['image', 'stylesheet']),
+  // Optionally enable Cooperative Mode for several request interceptors
+  interceptResolutionPriority: 0
 }))
 
 //

--- a/packages/puppeteer-extra-plugin-block-resources/readme.md
+++ b/packages/puppeteer-extra-plugin-block-resources/readme.md
@@ -34,10 +34,11 @@ Type: `function (opts)`
 Example:
 
 ```javascript
+const { DEFAULT_INTERCEPT_RESOLUTION_PRIORITY } = require('puppeteer')
 puppeteer.use(require('puppeteer-extra-plugin-block-resources')({
   blockedTypes: new Set(['image', 'stylesheet']),
   // Optionally enable Cooperative Mode for several request interceptors
-  interceptResolutionPriority: 0
+  interceptResolutionPriority: DEFAULT_INTERCEPT_RESOLUTION_PRIORITY
 }))
 
 //

--- a/packages/puppeteer-extra/package.json
+++ b/packages/puppeteer-extra/package.json
@@ -45,7 +45,7 @@
     "ava": "^2.4.0",
     "documentation-markdown-themes": "^12.1.5",
     "npm-run-all": "^4.1.5",
-    "puppeteer": "9",
+    "puppeteer": "10.2.0",
     "puppeteer-extra-plugin": "^3.2.0",
     "puppeteer-extra-plugin-anonymize-ua": "^2.3.3",
     "puppeteer-firefox": "^0.5.0",

--- a/packages/puppeteer-extra/package.json
+++ b/packages/puppeteer-extra/package.json
@@ -45,7 +45,7 @@
     "ava": "^2.4.0",
     "documentation-markdown-themes": "^12.1.5",
     "npm-run-all": "^4.1.5",
-    "puppeteer": "10.2.0",
+    "puppeteer": "^10.2.0",
     "puppeteer-extra-plugin": "^3.2.0",
     "puppeteer-extra-plugin-anonymize-ua": "^2.3.3",
     "puppeteer-firefox": "^0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,39 +1092,39 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
-"@cliqz/adblocker-content@^1.22.6":
-  version "1.22.6"
-  resolved "https://registry.yarnpkg.com/@cliqz/adblocker-content/-/adblocker-content-1.22.6.tgz#8a5910fd6b255eeeb697037a676fdc48b6bd7ce3"
-  integrity sha512-N9+ckQI+zJKlkdy6qPJsoyNU3yuxp7J2nwZq05WzfRxon9E3anODGKlZyn+MtfF9Vmmk7g+hObPFTganBx0q9Q==
+"@cliqz/adblocker-content@^1.23.0":
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/@cliqz/adblocker-content/-/adblocker-content-1.23.0.tgz#4417a28d6018138956898efa141c9e6f52c9ec34"
+  integrity sha512-X1osDX8pWGE1wGFnJqdY4qnwHI9Kb48Tom8HeZWTYDsf8VN636xUB5e5s4YZCTSfn271tFHYSdXNx3+TZqkkkQ==
   dependencies:
-    "@cliqz/adblocker-extended-selectors" "^1.22.6"
+    "@cliqz/adblocker-extended-selectors" "^1.23.0"
 
-"@cliqz/adblocker-extended-selectors@^1.22.6":
-  version "1.22.6"
-  resolved "https://registry.yarnpkg.com/@cliqz/adblocker-extended-selectors/-/adblocker-extended-selectors-1.22.6.tgz#35042785eb3dc8e653070bb7013267f3953e7788"
-  integrity sha512-wB0lP2qoeU8s0NttcXGhYchYsAQwtTvjEOs5at5/CSbwfvFedFx29vnSpsPXaOKDEINqywVpCtUYoN8+wVgI1w==
+"@cliqz/adblocker-extended-selectors@^1.23.0":
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/@cliqz/adblocker-extended-selectors/-/adblocker-extended-selectors-1.23.0.tgz#44e54a91ae6f4cbc24f76f5b0ce16ec03851c015"
+  integrity sha512-6Zl/wdGBuRd80ssmThOYS0L9u2t4lZElJXpxRB3Jp7uF6oL4LqSK4OKps4x8BktdQMgej6r5EhCh1avwu/13Bg==
 
-"@cliqz/adblocker-puppeteer@1.22.6":
-  version "1.22.6"
-  resolved "https://registry.yarnpkg.com/@cliqz/adblocker-puppeteer/-/adblocker-puppeteer-1.22.6.tgz#6b311c74ab8f144ab71f2c259b9e49fa76243e9b"
-  integrity sha512-Yg+64gsBfG8NKIJTKRg+sgK8G32W/z4qNEoMGdGJc7mdKVCn+y93WklDMO3pCy64u9jqUVS/Rd7z/Z96dX3K8Q==
+"@cliqz/adblocker-puppeteer@1.23.0":
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/@cliqz/adblocker-puppeteer/-/adblocker-puppeteer-1.23.0.tgz#cacfb435f5f5941ec30f53b55fc5acb062d7b1a7"
+  integrity sha512-2WeltnghK1zpFI+DkE53UT7Fyn+RMsp9BhWXVqMUL09TF/o+uZroX42quA3xTY1/1SxX+0XTWEivmMX//9BxnQ==
   dependencies:
-    "@cliqz/adblocker" "^1.22.6"
-    "@cliqz/adblocker-content" "^1.22.6"
+    "@cliqz/adblocker" "^1.23.0"
+    "@cliqz/adblocker-content" "^1.23.0"
     tldts-experimental "^5.6.21"
 
-"@cliqz/adblocker@^1.22.6":
-  version "1.22.6"
-  resolved "https://registry.yarnpkg.com/@cliqz/adblocker/-/adblocker-1.22.6.tgz#400b8c41da9a9a3b45da8774d2cd4333960e8988"
-  integrity sha512-f3GNYRiGyplZ79OJA1NLEWrnjWgKKLudupt07pKroesATKxC75hoLushY8F94ensKOLTs/7MTQyYRieVXgOEKg==
+"@cliqz/adblocker@^1.23.0":
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/@cliqz/adblocker/-/adblocker-1.23.0.tgz#a970d1199d36161a6154e27654cd7eb59a10a497"
+  integrity sha512-SRgSqEzFSN99zBeW3Or7ZW1uiIn+O2/Ol6KmZnsTZ/Wrn2RAQsm4wEzxPi6BSC3HpdJh2JdKuAwISavpmhuuvA==
   dependencies:
-    "@cliqz/adblocker-content" "^1.22.6"
-    "@cliqz/adblocker-extended-selectors" "^1.22.6"
+    "@cliqz/adblocker-content" "^1.23.0"
+    "@cliqz/adblocker-extended-selectors" "^1.23.0"
     "@remusao/guess-url-type" "^1.1.2"
     "@remusao/small" "^1.1.2"
     "@remusao/smaz" "^1.7.1"
-    "@types/chrome" "^0.0.157"
-    "@types/firefox-webext-browser" "^82.0.0"
+    "@types/chrome" "^0.0.159"
+    "@types/firefox-webext-browser" "^94.0.0"
     tldts-experimental "^5.6.21"
 
 "@concordance/react@^2.0.0":
@@ -2091,10 +2091,10 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@types/chrome@^0.0.157":
-  version "0.0.157"
-  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.157.tgz#5a50bd378f4f632383c6ebbc34c88fb87d501f58"
-  integrity sha512-q5SSmA9nKaDzFi8QkJW9kW8MYwWg9O7PKPUdBxsz+3rPcIF1Kxw0Bexpd70Uq1mU6PN4DBp4qKMXQDybUeiI9w==
+"@types/chrome@^0.0.159":
+  version "0.0.159"
+  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.159.tgz#0c1125fbb6d1fd64713e35de9aafbfd5a1b7a33a"
+  integrity sha512-WZBkNJGAwZuRgv/an94DANdzFtJK0TvlO/evMpJD/TYnkjIxynIAU6RM7M78e8tyig/vD6weQ9T1Ba7v8nYjXQ==
   dependencies:
     "@types/filesystem" "*"
     "@types/har-format" "*"
@@ -2123,10 +2123,10 @@
   resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.29.tgz#a48795ecadf957f6c0d10e0c34af86c098fa5bee"
   integrity sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==
 
-"@types/firefox-webext-browser@^82.0.0":
-  version "82.0.1"
-  resolved "https://registry.yarnpkg.com/@types/firefox-webext-browser/-/firefox-webext-browser-82.0.1.tgz#197dec1d175b099eb8dac92e9c9c9a5482a5dd8a"
-  integrity sha512-odcPKiJ34N8k53clIWen3hLvl09ja7SQ9NqtUbgmqeJ/a/ZRQiF665iXSFPcnl6cBn2XQgEg2lsUUApYNiyj+g==
+"@types/firefox-webext-browser@^94.0.0":
+  version "94.0.0"
+  resolved "https://registry.yarnpkg.com/@types/firefox-webext-browser/-/firefox-webext-browser-94.0.0.tgz#8a470475ab111e47d34e2599034e227feece09f9"
+  integrity sha512-DU6rySaklQlzc3tnVAFNgK2OGkOKCDze8ZlhQFtx+Ag4w2rzgNFoqlwQHrUqUogRJph7Gxf1M8e9n4mlYlragw==
 
 "@types/glob@^7.1.1":
   version "7.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,34 +1092,34 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
-"@cliqz/adblocker-content@^1.23.1":
-  version "1.23.1"
-  resolved "https://registry.yarnpkg.com/@cliqz/adblocker-content/-/adblocker-content-1.23.1.tgz#4c65c8cf82e21731eee6ecb92708229038cad45a"
-  integrity sha512-xOmwu4LsCfg89O7AwLEhxdiLN4pHOXcKAwd6LQAWbp0wjFoT9tuUOwrbyPSGjH7KDIM3qkW0pA94qEhuX1BxCg==
+"@cliqz/adblocker-content@^1.23.2":
+  version "1.23.2"
+  resolved "https://registry.yarnpkg.com/@cliqz/adblocker-content/-/adblocker-content-1.23.2.tgz#f4fa9eedf55a47e0a6d09396b3f344855f7b5460"
+  integrity sha512-J2jRtd1l3O/bDlXLBFgzC8Z/M84k2SL1pzqpoLRxYrJ3VbDv2ZgrIjUkTBR8hExKZ1DHnGYOrZD014N0YRQvVw==
   dependencies:
-    "@cliqz/adblocker-extended-selectors" "^1.23.1"
+    "@cliqz/adblocker-extended-selectors" "^1.23.2"
 
-"@cliqz/adblocker-extended-selectors@^1.23.1":
-  version "1.23.1"
-  resolved "https://registry.yarnpkg.com/@cliqz/adblocker-extended-selectors/-/adblocker-extended-selectors-1.23.1.tgz#373b8217aeee65786447c9b58f3993dfe4bf3e33"
-  integrity sha512-wjBJmDvWZeyCcYjc21ucW/9RfzXzYbri3yke1b+PBD2XbViyZPr6/O9fQFZr5qrSD7CC+7vaK2UloKJpstqm7A==
+"@cliqz/adblocker-extended-selectors@^1.23.2":
+  version "1.23.2"
+  resolved "https://registry.yarnpkg.com/@cliqz/adblocker-extended-selectors/-/adblocker-extended-selectors-1.23.2.tgz#f49519c7639ecdebc09a459fffe876a97ef96a69"
+  integrity sha512-JokCWTcw0XjBxAv7WGzfVfdGjz6OsND4eEhEQUDXxzkzbv4qOe8T+fi42lphfshlt89svAIl18zKp0Ibx9H9Vw==
 
-"@cliqz/adblocker-puppeteer@1.23.1":
-  version "1.23.1"
-  resolved "https://registry.yarnpkg.com/@cliqz/adblocker-puppeteer/-/adblocker-puppeteer-1.23.1.tgz#8673ee1861c2d23a993707cafc360772a4c1d1af"
-  integrity sha512-+c1A58nxvhFqvcHOcWbP7CBM2CoEM/xOg38ig4bgGzU8/sObQdL+WbSEVFlupgse05AeeOzozTsgPTxN5smuaA==
+"@cliqz/adblocker-puppeteer@1.23.2":
+  version "1.23.2"
+  resolved "https://registry.yarnpkg.com/@cliqz/adblocker-puppeteer/-/adblocker-puppeteer-1.23.2.tgz#28e41f07d7684c82d6df1c3e9a48f91849941c63"
+  integrity sha512-bzI8HF5KSNQRGIlUr3RRln+vIadOWozbsvE3vSyFZ0u0IeQWaPLoLrl0vJ1aTRRckqYwb4mtZKarwQcqII8hHw==
   dependencies:
-    "@cliqz/adblocker" "^1.23.1"
-    "@cliqz/adblocker-content" "^1.23.1"
+    "@cliqz/adblocker" "^1.23.2"
+    "@cliqz/adblocker-content" "^1.23.2"
     tldts-experimental "^5.6.21"
 
-"@cliqz/adblocker@^1.23.1":
-  version "1.23.1"
-  resolved "https://registry.yarnpkg.com/@cliqz/adblocker/-/adblocker-1.23.1.tgz#2b627e62db76af91f27d4212ea72da8d9dc43deb"
-  integrity sha512-Urio6l08ABay13qL0XPInjlBL2/PNqfQaHwEnyL1jLvF0qo/MnndzO0g3k5VXbfSeS42VVMxXR5EqeHtCfwJtw==
+"@cliqz/adblocker@^1.23.2":
+  version "1.23.2"
+  resolved "https://registry.yarnpkg.com/@cliqz/adblocker/-/adblocker-1.23.2.tgz#49f2f493c8e41cdc213505e02559a7797c8521df"
+  integrity sha512-u4u/iunhMoCQanfzvruBjNSqP9lu+y8tub3zhPZwtyrmmkXFcEark09/3qvq4jBCzqZQjdDjHlWaX6k1PjnUmg==
   dependencies:
-    "@cliqz/adblocker-content" "^1.23.1"
-    "@cliqz/adblocker-extended-selectors" "^1.23.1"
+    "@cliqz/adblocker-content" "^1.23.2"
+    "@cliqz/adblocker-extended-selectors" "^1.23.2"
     "@remusao/guess-url-type" "^1.1.2"
     "@remusao/small" "^1.1.2"
     "@remusao/smaz" "^1.7.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,38 +1092,38 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
-"@cliqz/adblocker-content@^1.23.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@cliqz/adblocker-content/-/adblocker-content-1.23.0.tgz#4417a28d6018138956898efa141c9e6f52c9ec34"
-  integrity sha512-X1osDX8pWGE1wGFnJqdY4qnwHI9Kb48Tom8HeZWTYDsf8VN636xUB5e5s4YZCTSfn271tFHYSdXNx3+TZqkkkQ==
+"@cliqz/adblocker-content@^1.23.1":
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/@cliqz/adblocker-content/-/adblocker-content-1.23.1.tgz#4c65c8cf82e21731eee6ecb92708229038cad45a"
+  integrity sha512-xOmwu4LsCfg89O7AwLEhxdiLN4pHOXcKAwd6LQAWbp0wjFoT9tuUOwrbyPSGjH7KDIM3qkW0pA94qEhuX1BxCg==
   dependencies:
-    "@cliqz/adblocker-extended-selectors" "^1.23.0"
+    "@cliqz/adblocker-extended-selectors" "^1.23.1"
 
-"@cliqz/adblocker-extended-selectors@^1.23.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@cliqz/adblocker-extended-selectors/-/adblocker-extended-selectors-1.23.0.tgz#44e54a91ae6f4cbc24f76f5b0ce16ec03851c015"
-  integrity sha512-6Zl/wdGBuRd80ssmThOYS0L9u2t4lZElJXpxRB3Jp7uF6oL4LqSK4OKps4x8BktdQMgej6r5EhCh1avwu/13Bg==
+"@cliqz/adblocker-extended-selectors@^1.23.1":
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/@cliqz/adblocker-extended-selectors/-/adblocker-extended-selectors-1.23.1.tgz#373b8217aeee65786447c9b58f3993dfe4bf3e33"
+  integrity sha512-wjBJmDvWZeyCcYjc21ucW/9RfzXzYbri3yke1b+PBD2XbViyZPr6/O9fQFZr5qrSD7CC+7vaK2UloKJpstqm7A==
 
-"@cliqz/adblocker-puppeteer@1.23.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@cliqz/adblocker-puppeteer/-/adblocker-puppeteer-1.23.0.tgz#cacfb435f5f5941ec30f53b55fc5acb062d7b1a7"
-  integrity sha512-2WeltnghK1zpFI+DkE53UT7Fyn+RMsp9BhWXVqMUL09TF/o+uZroX42quA3xTY1/1SxX+0XTWEivmMX//9BxnQ==
+"@cliqz/adblocker-puppeteer@1.23.1":
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/@cliqz/adblocker-puppeteer/-/adblocker-puppeteer-1.23.1.tgz#8673ee1861c2d23a993707cafc360772a4c1d1af"
+  integrity sha512-+c1A58nxvhFqvcHOcWbP7CBM2CoEM/xOg38ig4bgGzU8/sObQdL+WbSEVFlupgse05AeeOzozTsgPTxN5smuaA==
   dependencies:
-    "@cliqz/adblocker" "^1.23.0"
-    "@cliqz/adblocker-content" "^1.23.0"
+    "@cliqz/adblocker" "^1.23.1"
+    "@cliqz/adblocker-content" "^1.23.1"
     tldts-experimental "^5.6.21"
 
-"@cliqz/adblocker@^1.23.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@cliqz/adblocker/-/adblocker-1.23.0.tgz#a970d1199d36161a6154e27654cd7eb59a10a497"
-  integrity sha512-SRgSqEzFSN99zBeW3Or7ZW1uiIn+O2/Ol6KmZnsTZ/Wrn2RAQsm4wEzxPi6BSC3HpdJh2JdKuAwISavpmhuuvA==
+"@cliqz/adblocker@^1.23.1":
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/@cliqz/adblocker/-/adblocker-1.23.1.tgz#2b627e62db76af91f27d4212ea72da8d9dc43deb"
+  integrity sha512-Urio6l08ABay13qL0XPInjlBL2/PNqfQaHwEnyL1jLvF0qo/MnndzO0g3k5VXbfSeS42VVMxXR5EqeHtCfwJtw==
   dependencies:
-    "@cliqz/adblocker-content" "^1.23.0"
-    "@cliqz/adblocker-extended-selectors" "^1.23.0"
+    "@cliqz/adblocker-content" "^1.23.1"
+    "@cliqz/adblocker-extended-selectors" "^1.23.1"
     "@remusao/guess-url-type" "^1.1.2"
     "@remusao/small" "^1.1.2"
     "@remusao/smaz" "^1.7.1"
-    "@types/chrome" "^0.0.159"
+    "@types/chrome" "^0.0.164"
     "@types/firefox-webext-browser" "^94.0.0"
     tldts-experimental "^5.6.21"
 
@@ -2091,10 +2091,10 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@types/chrome@^0.0.159":
-  version "0.0.159"
-  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.159.tgz#0c1125fbb6d1fd64713e35de9aafbfd5a1b7a33a"
-  integrity sha512-WZBkNJGAwZuRgv/an94DANdzFtJK0TvlO/evMpJD/TYnkjIxynIAU6RM7M78e8tyig/vD6weQ9T1Ba7v8nYjXQ==
+"@types/chrome@^0.0.164":
+  version "0.0.164"
+  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.164.tgz#0a7669cf7225df0c472c69f73ef4b7b1d2d94013"
+  integrity sha512-/EvjbfcowiA+f8Fwv5PSzxHhnAgjIx50Bjy1zQQYYwxlbJ+rI07CXMhrxwz4jUZlxLjnn/kugNQBjZIN58pKyg==
   dependencies:
     "@types/filesystem" "*"
     "@types/har-format" "*"
@@ -3941,11 +3941,6 @@ detective@^4.0.0:
   dependencies:
     acorn "^5.2.1"
     defined "^1.0.0"
-
-devtools-protocol@0.0.854822:
-  version "0.0.854822"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.854822.tgz#eac3a5260a6b3b4e729a09fdc0c77b0d322e777b"
-  integrity sha512-xd4D8kHQtB0KtWW0c9xBZD5LVtm9chkMOfs/3Yn01RhT/sFIsVtzTtypfKoFfWBaL+7xCYLxjOLkhwPXaX/Kcg==
 
 devtools-protocol@0.0.869402:
   version "0.0.869402"
@@ -8411,6 +8406,24 @@ puppeteer@9:
     unbzip2-stream "^1.3.3"
     ws "^7.2.3"
 
+puppeteer@^10.2.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-10.4.0.tgz#a6465ff97fda0576c4ac29601406f67e6fea3dc7"
+  integrity sha512-2cP8mBoqnu5gzAVpbZ0fRaobBWZM8GEUF4I1F6WbgHrKV/rz7SX8PG2wMymZgD0wo0UBlg2FBPNxlF/xlqW6+w==
+  dependencies:
+    debug "4.3.1"
+    devtools-protocol "0.0.901419"
+    extract-zip "2.0.1"
+    https-proxy-agent "5.0.0"
+    node-fetch "2.6.1"
+    pkg-dir "4.2.0"
+    progress "2.0.1"
+    proxy-from-env "1.1.0"
+    rimraf "3.0.2"
+    tar-fs "2.0.0"
+    unbzip2-stream "1.3.3"
+    ws "7.4.6"
+
 puppeteer@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-2.1.1.tgz#ccde47c2a688f131883b50f2d697bd25189da27e"
@@ -8426,24 +8439,6 @@ puppeteer@^2.0.0:
     proxy-from-env "^1.0.0"
     rimraf "^2.6.1"
     ws "^6.1.0"
-
-puppeteer@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-8.0.0.tgz#a236669118aa795331c2d0ca19877159e7664705"
-  integrity sha512-D0RzSWlepeWkxPPdK3xhTcefj8rjah1791GE82Pdjsri49sy11ci/JQsAO8K2NRukqvwEtcI+ImP5F4ZiMvtIQ==
-  dependencies:
-    debug "^4.1.0"
-    devtools-protocol "0.0.854822"
-    extract-zip "^2.0.0"
-    https-proxy-agent "^5.0.0"
-    node-fetch "^2.6.1"
-    pkg-dir "^4.2.0"
-    progress "^2.0.1"
-    proxy-from-env "^1.1.0"
-    rimraf "^3.0.2"
-    tar-fs "^2.0.0"
-    unbzip2-stream "^1.3.3"
-    ws "^7.2.3"
 
 q@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
Adds support for the new [Cooperative Intercept Mode available in Puppeteer v11+](https://github.com/puppeteer/puppeteer/blob/v11.0.0/docs/api.md#upgrading-to-cooperative-mode-for-package-maintainers) and defining a custom `interceptResolutionPriority` for the following plugins:
- `puppeteer-extra-plugin-block-resources`
- `puppeteer-extra-plugin-block-adblocker`

This change checks that the required interception functions are available, so it's backwards compatible with the Legacy Mode and previous Puppeteer versions.

The `@cliqz/adblocker-puppeteer` dependency [already included support for Cooperative Mode in v1.23.0](https://github.com/cliqz-oss/adblocker/blob/master/packages/adblocker-puppeteer/CHANGELOG.md#v1230-mon-oct-18-2021).

Fixes #364, #156