### PR TITLE
Append patch version to UA hint platform version

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
@@ -129,14 +129,16 @@ class Plugin extends PuppeteerExtraPlugin {
       return greasedBrandVersionList
     }
 
+	const _padPlatformVersion = (version) => version+((version.split('.').length<=2)?'.0':'')
+
     // Return OS version
     const _getPlatformVersion = () => {
       if (ua.includes('Mac OS X ')) {
-        return ua.match(/Mac OS X ([^)]+)/)[1]
+        return _padPlatformVersion(ua.match(/Mac OS X ([^)]+)/)[1])
       } else if (ua.includes('Android ')) {
-        return ua.match(/Android ([^;]+)/)[1]
+        return _padPlatformVersion(ua.match(/Android ([^;]+)/)[1])
       } else if (ua.includes('Windows ')) {
-        return ua.match(/Windows .*?([\d|.]+);?/)[1]
+        return _padPlatformVersion(ua.match(/Windows .*?([\d|.]+);?/)[1])
       } else {
         return ''
       }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-CH-UA-Platform-Version
Sec-CH-UA-Platform-Version contains `dot-separated major, minor and patch version numbers`
The user agent may not contains 3 numbers, example on windows 10 it contains Windows 10.0, so we add the patch version at the end.

Take note that on linux the version seems to contains the kernel version, which this evasion doesn't get so if you set `maskLinux` to false on linux, the platformVersion will be empty while it shouldn't.

On android, on my phone on android 11, there is no header `Sec-CH-UA-Platform-Version` so i don't know if it must be removed

The bitness is also not filled.