### PR TITLE
fix(plugin-recaptcha): Change `hcaptcha.com` script recognition url

### DIFF
--- a/packages/puppeteer-extra-plugin-recaptcha/src/index.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/index.ts
@@ -143,7 +143,7 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
       this.debug('waitForRecaptchaClient - end', new Date()) // used as timer
     }
     const hasHcaptchaScriptTag = await page.$(
-      `script[src*="//hcaptcha.com/1/api.js"]`
+      `script[src*="hcaptcha.com/1/api.js"]`
     )
     this.debug('hasHcaptchaScriptTag', !!hasHcaptchaScriptTag)
     if (hasHcaptchaScriptTag) {


### PR DESCRIPTION
I encountered a different syntax today for a hcaptcha js script on a Cloudflare page:
```
https://cloudflare.hcaptcha.com/1/api.js?endpoint=https%3A%2F%2Fcloudflare.hcaptcha.com&assethost=https%3A%2F%2Fcf-assets.hcaptcha.com&imghost=https%3A%2F%2Fcf-imgs.hcaptcha.com&render=explicit&recaptchacompat=off&onload=_cf_chl_hload
```

This url will not be recognized by the previous pattern since that one expected `//hcaptcha`, so i changed it to allow subdomains.