### PR TITLE
fix(plugin-recaptcha): Update hcaptcha challenge query selector

### DIFF
--- a/packages/puppeteer-extra-plugin-recaptcha/src/content-hcaptcha.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/content-hcaptcha.ts
@@ -65,7 +65,7 @@ export class HcaptchaContentScript {
   /** Find active challenges from invisible hcaptchas */
   private _findActiveChallenges() {
     const nodeList = document.querySelectorAll<HTMLIFrameElement>(
-      `div[style*='visible'] iframe[src*='${this.baseUrl}'][src*='hcaptcha-challenge.html'][src*='invisible']`
+      `div[style*='visible'] iframe[src*='${this.baseUrl}'][src*='hcaptcha.html'][src*='invisible']`
     )
     return Array.from(nodeList)
   }


### PR DESCRIPTION
The query selector from the method `_findActiveChallenges` changed, so I updated it.

However, I didn't find a good way to test this, because the `test('will detect hCAPTCHAs')` uses [this url](http://democaptcha.com/demo-form-eng/hcaptcha.html) and it is tested by the method `_findRegularCheckboxes`.

