### PR TITLE
fix(plugin-stealth): Support puppeteer 14 private cdp client

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/defaultArgs/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/defaultArgs/index.test.js
@@ -7,7 +7,6 @@ const { argsToIgnore } = require('.')
 test('vanilla: uses args to ignore', async t => {
   const browser = await vanillaPuppeteer.launch({ headless: true })
   const page = await browser.newPage()
-  
   const { arguments: launchArgs } = await (typeof page._client === 'function' && page._client() || page._client).send(
     'Browser.getBrowserCommandLine'
   )
@@ -22,7 +21,6 @@ test('stealth: does not use args to ignore', async t => {
   const puppeteer = addExtra(vanillaPuppeteer).use(Plugin())
   const browser = await puppeteer.launch({ headless: true })
   const page = await browser.newPage()
-
   const { arguments: launchArgs } = await (typeof page._client === 'function' && page._client() || page._client).send(
     'Browser.getBrowserCommandLine'
   )

--- a/packages/puppeteer-extra-plugin-stealth/evasions/defaultArgs/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/defaultArgs/index.test.js
@@ -7,7 +7,8 @@ const { argsToIgnore } = require('.')
 test('vanilla: uses args to ignore', async t => {
   const browser = await vanillaPuppeteer.launch({ headless: true })
   const page = await browser.newPage()
-  const { arguments: launchArgs } = await page._client.send(
+  
+  const { arguments: launchArgs } = await (typeof page._client === 'function' && page._client() || page._client).send(
     'Browser.getBrowserCommandLine'
   )
   const ok = argsToIgnore.every(arg => launchArgs.includes(arg))
@@ -21,7 +22,8 @@ test('stealth: does not use args to ignore', async t => {
   const puppeteer = addExtra(vanillaPuppeteer).use(Plugin())
   const browser = await puppeteer.launch({ headless: true })
   const page = await browser.newPage()
-  const { arguments: launchArgs } = await page._client.send(
+
+  const { arguments: launchArgs } = await (typeof page._client === 'function' && page._client() || page._client).send(
     'Browser.getBrowserCommandLine'
   )
   const ok = argsToIgnore.every(arg => !launchArgs.includes(arg))

--- a/packages/puppeteer-extra-plugin-stealth/evasions/sourceurl/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/sourceurl/index.js
@@ -16,7 +16,7 @@ class Plugin extends PuppeteerExtraPlugin {
   }
 
   async onPageCreated(page) {
-    if (!page || !page._client || !page._client.send) {
+    if (!page || !page._client || (typeof page._client === 'function' && !page._client().send) || !page._client.send) {
       this.debug('Warning, missing properties to intercept CDP.', { page })
       return
     }
@@ -24,7 +24,7 @@ class Plugin extends PuppeteerExtraPlugin {
     // Intercept CDP commands and strip identifying and unnecessary sourceURL
     // https://github.com/puppeteer/puppeteer/blob/9b3005c105995cd267fdc7fb95b78aceab82cf0e/new-docs/puppeteer.cdpsession.md
     const debug = this.debug
-    page._client.send = (function(originalMethod, context) {
+    (typeof page._client === 'function' && page._client() || page._client).send = (function(originalMethod, context) {
       return async function() {
         const [method, paramArgs] = arguments || []
         const next = async () => {
@@ -64,7 +64,7 @@ class Plugin extends PuppeteerExtraPlugin {
 
         return next()
       }
-    })(page._client.send, page._client)
+    })((typeof page._client === 'function' && page._client() || page._client).send, (typeof page._client === 'function' && page._client() || page._client))
   }
 }
 

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
@@ -177,7 +177,7 @@ class Plugin extends PuppeteerExtraPlugin {
       opts: this.opts
     })
 
-    page._client.send('Network.setUserAgentOverride', override)
+    (typeof page._client === 'function' && page._client() || page._client).send('Network.setUserAgentOverride', override)
   }
 
   async beforeLaunch(options) {


### PR DESCRIPTION
It's just an example. I'm sure it could be nicer, but it works (at least for me; I couldn't run the tests because of Windows and there comes the error "Failed to download Firefox rv0.0.1!"). No time to fix this error.

**Edit:** 
The problem is that `puppeteer@14` has finally made '#client' private. However, there is still/or now the function `Page._client()`, which returns the client. To avoid problems between `<@14` and `>=@14`, I made it a bit "uglier".

**Edit (2):**
I had to make a 2nd commit because for some reason the 1st push didn't push the changes to the defaultArg test(s). (And another one to remove the dummy blank spaces.)