### PR TITLE
fix(plugin-stealth): Revert iframe.contentWindow changes and add tests

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow/index.js
@@ -27,42 +27,103 @@ class Plugin extends PuppeteerExtraPlugin {
   async onPageCreated(page) {
     await withUtils(page).evaluateOnNewDocument((utils, opts) => {
       try {
-        // Add a cache to not recreate the proxy and to keep the same object
-        // between two calls (to keep the possible modifications made by the
-        // website).
-        const proxifyContentWindow = utils.memoize(contentWindow => {
-          // If the iframe isn't in the DOM, it has no contentWindow.
-          if (contentWindow === null) {
-            return null
-          }
-          return new Proxy(contentWindow, {
-            get(target, prop) {
-              if (
-                prop === 'chrome' &&
-                Reflect.get(target, prop) === undefined
-              ) {
-                return window.chrome
+        // Adds a contentWindow proxy to the provided iframe element
+        const addContentWindowProxy = iframe => {
+          const contentWindowProxy = {
+            get(target, key) {
+              // Now to the interesting part:
+              // We actually make this thing behave like a regular iframe window,
+              // by intercepting calls to e.g. `.self` and redirect it to the correct thing. :)
+              // That makes it possible for these assertions to be correct:
+              // iframe.contentWindow.self === window.top // must be false
+              if (key === 'self') {
+                return this
               }
-              if (prop === 'navigator') {
-                return window.navigator
+              // iframe.contentWindow.frameElement === iframe // must be true
+              if (key === 'frameElement') {
+                return iframe
               }
-              return Reflect.get(target, prop)
+              // Intercept iframe.contentWindow[0] to hide the property 0 added by the proxy.
+              if (key === '0') {
+                return undefined
+              }
+              return Reflect.get(target, key)
             }
-          })
-        })
+          }
 
-        const handler = {
-          get: function(nativeFn) {
-            return proxifyContentWindow(nativeFn())
+          if (!iframe.contentWindow) {
+            const proxy = new Proxy(window, contentWindowProxy)
+            Object.defineProperty(iframe, 'contentWindow', {
+              get() {
+                return proxy
+              },
+              set(newValue) {
+                return newValue // contentWindow is immutable
+              },
+              enumerable: true,
+              configurable: false
+            })
           }
         }
 
-        utils.replaceGetterSetter(
-          // eslint-disable-next-line no-undef
-          HTMLIFrameElement.prototype,
-          'contentWindow',
-          handler
-        )
+        // Handles iframe element creation, augments `srcdoc` property so we can intercept further
+        const handleIframeCreation = (target, thisArg, args) => {
+          const iframe = target.apply(thisArg, args)
+
+          // We need to keep the originals around
+          const _iframe = iframe
+          const _srcdoc = _iframe.srcdoc
+
+          // Add hook for the srcdoc property
+          // We need to be very surgical here to not break other iframes by accident
+          Object.defineProperty(iframe, 'srcdoc', {
+            configurable: true, // Important, so we can reset this later
+            get: function() {
+              return _srcdoc
+            },
+            set: function(newValue) {
+              addContentWindowProxy(this)
+              // Reset property, the hook is only needed once
+              Object.defineProperty(iframe, 'srcdoc', {
+                configurable: false,
+                writable: false,
+                value: _srcdoc
+              })
+              _iframe.srcdoc = newValue
+            }
+          })
+          return iframe
+        }
+
+        // Adds a hook to intercept iframe creation events
+        const addIframeCreationSniffer = () => {
+          /* global document */
+          const createElementHandler = {
+            // Make toString() native
+            get(target, key) {
+              return Reflect.get(target, key)
+            },
+            apply: function(target, thisArg, args) {
+              const isIframe =
+                args && args.length && `${args[0]}`.toLowerCase() === 'iframe'
+              if (!isIframe) {
+                // Everything as usual
+                return target.apply(thisArg, args)
+              } else {
+                return handleIframeCreation(target, thisArg, args)
+              }
+            }
+          }
+          // All this just due to iframes with srcdoc bug
+          utils.replaceWithProxy(
+            document,
+            'createElement',
+            createElementHandler
+          )
+        }
+
+        // Let's go
+        addIframeCreationSniffer()
       } catch (err) {
         // console.warn(err)
       }


### PR DESCRIPTION
Unfortunately the changes in #565 would break captcha frames, I reverted the `iframe.contentWindow` changes until we had time to improve the new code.

I've also added/improved 3 captcha specific tests that make sure we don't break them in the future :)

@regseb if you want to improve the code feel free to do so, I left in your (now unused) utils additions and commented out the new tests that would break