### PR TITLE
feat: Add playwright-extra

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,9 @@ jobs:
     strategy:
       matrix:
         node:
-          - 15
+          - 16
           # - 14
-          - 12
+          - 14
         puppeteer_version:
           # - 14.2.0 # Chromium 103.0.5059.0 # requires >=14.1.0
           - 10.2.0 # Chromium 93.0.4577.0

--- a/packages/playwright-extra/.prettierrc.js
+++ b/packages/playwright-extra/.prettierrc.js
@@ -1,0 +1,1 @@
+module.exports = 'prettier-config-standard'

--- a/packages/playwright-extra/package.json
+++ b/packages/playwright-extra/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "playwright-extra",
+  "version": "3.3.0",
+  "description": "Teach playwright new tricks through plugins.",
+  "repository": "berstend/puppeteer-extra",
+  "homepage": "https://github.com/berstend/puppeteer-extra/tree/master/packages/playwright-extra#readme",
+  "author": "berstend",
+  "license": "MIT",
+  "typings": "dist/index.d.ts",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rimraf dist/*",
+    "prebuild": "run-s clean",
+    "build": "run-s build:tsc build:rollup ambient-dts",
+    "build:tsc": "tsc --module commonjs",
+    "build:rollup": "rollup -c rollup.config.ts",
+    "prepublishOnly": "run-s build",
+    "docs": "echo \"No docs\"",
+    "test": "yarn playwright test --config test/playwright.config.ts",
+    "test-ci": "run-s test",
+    "ambient-dts": "run-s ambient-dts-copy ambient-dts-fix-path",
+    "ambient-dts-copy": "copyfiles -u 1 \"src/**/*.d.ts\" dist",
+    "ambient-dts-fix-path": "replace-in-files --string='/// <reference path=\"../src/' --replacement='/// <reference path=\"../dist/' 'dist/**/*.d.ts'"
+  },
+  "keywords": [
+    "playwright",
+    "playwright-extra",
+    "stealth",
+    "recaptcha",
+    "user-preferences",
+    "chrome",
+    "headless",
+    "pupeteer"
+  ],
+  "engines": {
+    "node": ">=8"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.23.1",
+    "@types/debug": "^4.1.7",
+    "@types/node": "^18.0.0",
+    "esbuild": "^0.14.47",
+    "esbuild-register": "^3.3.3",
+    "npm-run-all": "^4.1.5",
+    "playwright": "^1.22.2",
+    "prettier": "^2.7.1",
+    "puppeteer-extra-plugin": "^3.2.0",
+    "puppeteer-extra-plugin-anonymize-ua": "^2.4.0",
+    "rimraf": "^3.0.0",
+    "rollup": "^1.27.5",
+    "rollup-plugin-commonjs": "^10.1.0",
+    "rollup-plugin-node-resolve": "^5.2.0",
+    "rollup-plugin-sourcemaps": "^0.4.2",
+    "rollup-plugin-typescript2": "^0.25.2",
+    "typescript": "4.4.3"
+  },
+  "peerDependencies": {},
+  "dependencies": {
+    "debug": "^4.3.4"
+  }
+}

--- a/packages/playwright-extra/readme.md
+++ b/packages/playwright-extra/readme.md
@@ -1,0 +1,271 @@
+# playwright-extra [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/berstend/puppeteer-extra/Test/master)](https://github.com/berstend/puppeteer-extra/actions) [![Discord](https://img.shields.io/discord/737009125862408274)](https://extra.community) [![npm](https://img.shields.io/npm/v/playwright-extra.svg)](https://www.npmjs.com/package/playwright-extra)
+
+> A modular plugin framework for [playwright](https://github.com/microsoft/playwright) to enable cool [plugins](#plugins) through a clean interface.
+
+## Installation
+
+```bash
+yarn add playwright playwright-extra
+# - or -
+npm install playwright playwright-extra
+```
+
+<details>
+ <summary>Changelog</summary>
+
+> Please check the `announcements` channel in our [discord server](https://extra.community) until we've automated readme updates. :)
+
+- **v3.3**
+  - Initial public release
+  </details>
+
+## Quickstart
+
+```js
+// playwright-extra is a drop-in replacement for playwright,
+// it augments the installed playwright with plugin functionality
+const { chromium } = require('playwright-extra')
+
+// Load the stealth plugin and use defaults (all tricks to hide playwright usage)
+// Note: playwright-extra is compatible with most puppeteer-extra plugins
+const stealth = require('puppeteer-extra-plugin-stealth')()
+
+// Add the plugin to playwright (any number of plugins can be added)
+chromium.use(stealth)
+
+// That's it, the rest is playwright usage as normal 😊
+chromium.launch({ headless: true }).then(async browser => {
+  const page = await browser.newPage()
+
+  console.log('Testing the stealth plugin..')
+  await page.goto('https://bot.sannysoft.com', { waitUntil: 'networkidle' })
+  await page.screenshot({ path: 'stealth.png', fullPage: true })
+
+  console.log('All done, check the screenshot. ✨')
+  await browser.close()
+})
+```
+
+The above example uses the compatible [`stealth`](/packages/puppeteer-extra-plugin-stealth) plugin from puppeteer-extra, that plugin needs to be installed as well:
+
+```bash
+yarn add puppeteer-extra-plugin-stealth
+# - or -
+npm install puppeteer-extra-plugin-stealth
+```
+
+If you'd like to see debug output just run your script like so:
+
+```bash
+DEBUG=playwright-extra*,puppeteer-extra* node myscript.js
+```
+
+### More examples
+
+<details>
+ <summary><strong>TypeScript & ESM usage</strong></summary><br/>
+
+`playwright-extra` and most plugins are written in TS, so you get perfect type support out of the box. :)
+
+```ts
+// playwright-extra is a drop-in replacement for playwright,
+// it augments the installed playwright with plugin functionality
+import { chromium } from 'playwright-extra'
+
+// Load the stealth plugin and use defaults (all tricks to hide playwright usage)
+// Note: playwright-extra is compatible with most puppeteer-extra plugins
+import StealthPlugin from 'puppeteer-extra-plugin-stealth'
+
+// Add the plugin to playwright (any number of plugins can be added)
+chromium.use(StealthPlugin())
+
+// ...(the rest of the quickstart code example is the same)
+chromium.launch({ headless: true }).then(async browser => {
+  const page = await browser.newPage()
+
+  console.log('Testing the stealth plugin..')
+  await page.goto('https://bot.sannysoft.com', { waitUntil: 'networkidle' })
+  await page.screenshot({ path: 'stealth.png', fullPage: true })
+
+  console.log('All done, check the screenshot. ✨')
+  await browser.close()
+})
+```
+
+New to Typescript? Here it is in 30 seconds or less 😄:
+
+```bash
+# Optional: If you don't have yarn yet
+npm i --global yarn
+
+# Optional: Create new package.json if it's a new project
+yarn init -y
+
+# Add basic typescript dependencies
+yarn add --dev typescript @types/node esbuild esbuild-register
+
+# Bootstrap a tsconfig.json
+yarn tsc --init --target ES2020 --lib ES2020 --module commonjs --rootDir src --outDir dist
+
+# Add dependencies used in the quick start example
+yarn add playwright playwright-extra puppeteer-extra-plugin-stealth
+
+# Create source folder for the .ts files
+mkdir src
+
+# Now place the example code above in `src/index.ts`
+
+# Run the typescript code without the need of compiling it first
+node -r esbuild-register src/index.ts
+
+# You can now add Typescript to your CV 🎉
+```
+
+</details>
+<details>
+ <summary><strong>Using different browsers</strong></summary><br/>
+
+```ts
+// Any browser supported by playwright can be used with plugins
+import { chromium, firefox, webkit } from 'playwright-extra'
+
+chromium.use(plugin)
+firefox.use(plugin)
+webkit.use(plugin)
+```
+
+</details>
+<details>
+ <summary><strong>Multiple instances with different plugins</strong></summary><br/>
+
+Node.js imports are cached, therefore the default `chromium`, `firefox`, `webkit` export from `playwright-extra` will always return the same playwright instance.
+
+```ts
+// Use `addExtra` to create a fresh and independent instance
+import playwright from 'playwright'
+import { addExtra } from 'playwright-extra'
+
+const chromium1 = addExtra(playwright.chromium)
+const chromium2 = addExtra(playwright.chromium)
+
+chromium1.use(onePlugin)
+chromium2.use(anotherPlugin)
+// chromium1 and chromium2 are independent
+```
+
+</details>
+
+---
+
+## Plugins
+
+We're currently in the process of making the existing [puppeteer-extra](/packages/puppeteer-extra) plugins compatible with playwright-extra, the following plugins have been successfully tested already:
+
+### 🔥 [`puppeteer-extra-plugin-stealth`](/packages/puppeteer-extra-plugin-stealth)
+
+- Applies various evasion techniques to make detection of an automated browser harder
+- Compatible with Puppeteer & Playwright and chromium based browsers
+
+<details>
+<summary>&nbsp;&nbsp;Example: Using stealth in Playwright with custom options</summary>
+
+```js
+// The stealth plugin is optimized for chromium based browsers currently
+import { chromium } from 'playwright-extra'
+
+import StealthPlugin from 'puppeteer-extra-plugin-stealth'
+chromium.use(StealthPlugin())
+
+// New way to overwrite the default options of stealth evasion plugins
+// https://github.com/berstend/puppeteer-extra/tree/master/packages/puppeteer-extra-plugin-stealth/evasions
+chromium.plugins.setDependencyDefaults('stealth/evasions/webgl.vendor', {
+  vendor: 'Bob',
+  renderer: 'Alice'
+})
+
+// That's it, the rest is playwright usage as normal 😊
+chromium.launch({ headless: true }).then(async browser => {
+  const page = await browser.newPage()
+
+  console.log('Testing the webgl spoofing feature of the stealth plugin..')
+  await page.goto('https://webglreport.com', { waitUntil: 'networkidle' })
+  await page.screenshot({ path: 'webgl.png', fullPage: true })
+
+  console.log('All done, check the screenshot. ✨')
+  await browser.close()
+})
+```
+
+</details>
+
+### 🏴 [`puppeteer-extra-plugin-recaptcha`](/packages/puppeteer-extra-plugin-recaptcha)
+
+- Solves reCAPTCHAs and hCaptchas automatically, using a single line of code: `page.solveRecaptchas()`
+- Compatible with Puppeteer & Playwright and all browsers (chromium, firefox, webkit)
+<details>
+<summary>&nbsp;&nbsp;Example: Solving captchas in Playwright & Firefox</summary>
+
+```js
+// Any browser (chromium, webkit, firefox) can be used
+import { firefox } from 'playwright-extra'
+
+import RecaptchaPlugin from 'puppeteer-extra-plugin-recaptcha'
+firefox.use(
+  RecaptchaPlugin({
+    provider: {
+      id: '2captcha',
+      token: process.env.TWOCAPTCHA_TOKEN || 'YOUR_API_KEY'
+    }
+  })
+)
+
+// Works in headless as well, just so you can see it in action
+firefox.launch({ headless: false }).then(async browser => {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  const url = 'https://www.google.com/recaptcha/api2/demo'
+  await page.goto(url, { waitUntil: 'networkidle' })
+
+  console.log('Solving captchas..')
+  await page.solveRecaptchas()
+
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: 'networkidle' }),
+    page.click(`#recaptcha-demo-submit`)
+  ])
+
+  const content = await page.content()
+  const isSuccess = content.includes('Verification Success')
+  console.log('Done', { isSuccess })
+  await browser.close()
+})
+```
+
+</details>
+
+**Notes**
+
+- If you're in need of adblocking use [this package](https://www.npmjs.com/package/@cliqz/adblocker-playwright) or [block resources natively](https://github.com/berstend/puppeteer-extra/wiki/Block-resources-without-request-interception)
+- We're focussing on compatiblity with existing plugins at the moment, more documentation on how to write your own playwright-extra plugins will follow
+
+---
+
+## Contributors
+
+<a href="https://github.com/berstend/puppeteer-extra/graphs/contributors">
+  <img src="https://contributors-img.firebaseapp.com/image?repo=berstend/puppeteer-extra" />
+</a>
+
+---
+
+## License
+
+Copyright © 2018 - 2022, [berstend̡̲̫̹̠̖͚͓̔̄̓̐̄͛̀͘](https://github.com/berstend). Released under the MIT License.
+
+<!--
+  Reference links
+-->
+
+[playwright-extra]: https://github.com/berstend/puppeteer-extra/tree/master/packages/playwright-extra
+[puppeteer-extra]: https://github.com/berstend/puppeteer-extra/tree/master/packages/puppeteer-extra
+[`puppeteer-extra`]: https://github.com/berstend/puppeteer-extra/tree/master/packages/puppeteer-extra

--- a/packages/playwright-extra/rollup.config.ts
+++ b/packages/playwright-extra/rollup.config.ts
@@ -1,0 +1,61 @@
+import commonjs from 'rollup-plugin-commonjs'
+import resolve from 'rollup-plugin-node-resolve'
+import sourceMaps from 'rollup-plugin-sourcemaps'
+import typescript from 'rollup-plugin-typescript2'
+
+const pkg = require('./package.json')
+
+const entryFile = 'index'
+const banner = `
+/*!
+ * ${pkg.name} v${pkg.version} by ${pkg.author}
+ * ${pkg.homepage || `https://github.com/${pkg.repository}`}
+ * @license ${pkg.license}
+ */
+`.trim()
+
+const defaultExportOutro = `
+  module.exports = exports.default || {}
+  Object.entries(exports).forEach(([key, value]) => { module.exports[key] = value })
+`
+
+export default {
+  input: `src/${entryFile}.ts`,
+  output: [
+    {
+      file: pkg.main,
+      format: 'cjs',
+      sourcemap: true,
+      exports: 'named',
+      outro: defaultExportOutro,
+      banner
+    },
+    {
+      file: pkg.module,
+      format: 'es',
+      sourcemap: true,
+      exports: 'named',
+      banner
+    }
+  ],
+  // Indicate here external modules you don't wanna include in your bundle (i.e.: 'lodash')
+  external: [
+    ...Object.keys(pkg.dependencies || {}),
+    ...Object.keys(pkg.peerDependencies || {})
+  ],
+  watch: {
+    include: 'src/**'
+  },
+  plugins: [
+    // Compile TypeScript files
+    typescript({ useTsconfigDeclarationDir: true }),
+    // Allow bundling cjs modules (unlike webpack, rollup doesn't understand cjs)
+    commonjs(),
+    // Allow node_modules resolution, so you can use 'external' to control
+    // which external modules to include in the bundle
+    // https://github.com/rollup/rollup-plugin-node-resolve#usage
+    resolve(),
+    // Resolve source maps to the original source
+    sourceMaps()
+  ]
+}

--- a/packages/playwright-extra/src/extra.ts
+++ b/packages/playwright-extra/src/extra.ts
@@ -1,0 +1,295 @@
+import Debug from 'debug'
+const debug = Debug('playwright-extra')
+
+import type * as pw from 'playwright-core'
+import type { CompatiblePlugin, Plugin } from './types'
+
+import { PluginList } from './plugins'
+import { playwrightLoader } from './helper/loader'
+
+type PlaywrightBrowserLauncher = pw.BrowserType
+
+/**
+ * The Playwright browser launcher APIs we're augmenting
+ * @private
+ */
+interface AugmentedLauncherAPIs
+  extends Pick<
+    PlaywrightBrowserLauncher,
+    'launch' | 'launchPersistentContext' | 'connect' | 'connectOverCDP'
+  > {}
+
+/**
+ * Modular plugin framework to teach `playwright` new tricks.
+ */
+export class PlaywrightExtraClass implements AugmentedLauncherAPIs {
+  /** Plugin manager */
+  public readonly plugins: PluginList
+
+  constructor(private _launcher?: Partial<PlaywrightBrowserLauncher>) {
+    this.plugins = new PluginList()
+  }
+
+  /**
+   * The **main interface** to register plugins.
+   *
+   * Can be called multiple times to enable multiple plugins.
+   *
+   * Plugins derived from `PuppeteerExtraPlugin` will be used with a compatiblity layer.
+   *
+   * @example
+   * chromium.use(plugin1).use(plugin2)
+   * firefox.use(plugin1).use(plugin2)
+   *
+   * @see [PuppeteerExtraPlugin]
+   *
+   * @return The same `PlaywrightExtra` instance (for optional chaining)
+   */
+  public use(plugin: CompatiblePlugin): this {
+    const isValid = plugin && 'name' in plugin
+    if (!isValid) {
+      throw new Error('A plugin must be provided to .use()')
+    }
+    if (this.plugins.add(plugin as Plugin)) {
+      debug('Plugin registered', plugin.name)
+    }
+    return this
+  }
+
+  /**
+   * In order to support a default export which will require vanilla playwright automatically,
+   * as well as `addExtra` to patch a provided launcher, we need to so some gymnastics here.
+   *
+   * Otherwise this would throw immediately, even when only using the `addExtra` export with an arbitrary compatible launcher.
+   *
+   * The solution is to make the vanilla launcher optional and only throw once we try to effectively use and can't find it.
+   *
+   * @internal
+   */
+  public get launcher(): Partial<PlaywrightBrowserLauncher> {
+    if (!this._launcher) {
+      throw playwrightLoader.requireError
+    }
+    return this._launcher
+  }
+
+  public async launch(
+    ...args: Parameters<PlaywrightBrowserLauncher['launch']>
+  ): ReturnType<PlaywrightBrowserLauncher['launch']> {
+    if (!this.launcher.launch) {
+      throw new Error('Launcher does not support "launch"')
+    }
+
+    let [options] = args
+    options = { args: [], ...(options || {}) } // Initialize args array
+    debug('launch', options)
+    this.plugins.prepare()
+
+    // Give plugins the chance to modify the options before continuing
+    options =
+      (await this.plugins.dispatchBlocking('beforeLaunch', options)) || options
+
+    debug('launch with options', options)
+    if ('userDataDir' in options) {
+      debug(
+        "A plugin defined userDataDir during .launch, which isn't supported by playwright - ignoring"
+      )
+      delete (options as any).userDataDir
+    }
+    const browser = await this.launcher['launch'](options)
+    await this.plugins.dispatchBlocking('onBrowser', browser)
+    await this._bindBrowserEvents(browser)
+    await this.plugins.dispatchBlocking('afterLaunch', browser)
+    return browser
+  }
+
+  public async launchPersistentContext(
+    ...args: Parameters<PlaywrightBrowserLauncher['launchPersistentContext']>
+  ): ReturnType<PlaywrightBrowserLauncher['launchPersistentContext']> {
+    if (!this.launcher.launchPersistentContext) {
+      throw new Error('Launcher does not support "launchPersistentContext"')
+    }
+
+    let [userDataDir, options] = args
+    options = { args: [], ...(options || {}) } // Initialize args array
+    debug('launchPersistentContext', options)
+    this.plugins.prepare()
+
+    // Give plugins the chance to modify the options before continuing
+    options =
+      (await this.plugins.dispatchBlocking('beforeLaunch', options)) || options
+
+    const context = await this.launcher['launchPersistentContext'](
+      userDataDir,
+      options
+    )
+    await this.plugins.dispatchBlocking('afterLaunch', context)
+    this._bindBrowserContextEvents(context)
+    return context
+  }
+
+  async connect(
+    wsEndpointOrOptions: string | (pw.ConnectOptions & { wsEndpoint?: string }),
+    wsOptions: pw.ConnectOptions = {}
+  ): ReturnType<PlaywrightBrowserLauncher['connect']> {
+    if (!this.launcher.connect) {
+      throw new Error('Launcher does not support "connect"')
+    }
+    this.plugins.prepare()
+
+    // Playwright currently supports two function signatures for .connect
+    let options: pw.ConnectOptions & { wsEndpoint?: string } = {}
+    let wsEndpointAsString = false
+    if (typeof wsEndpointOrOptions === 'object') {
+      options = { ...wsEndpointOrOptions, ...wsOptions }
+    } else {
+      wsEndpointAsString = true
+      options = { wsEndpoint: wsEndpointOrOptions, ...wsOptions }
+    }
+    debug('connect', options)
+
+    // Give plugins the chance to modify the options before launch/connect
+    options =
+      (await this.plugins.dispatchBlocking('beforeConnect', options)) || options
+
+    // Follow call signature of end user
+    const args: any[] = []
+    const wsEndpoint = options.wsEndpoint
+    if (wsEndpointAsString) {
+      delete options.wsEndpoint
+      args.push(wsEndpoint, options)
+    } else {
+      args.push(options)
+    }
+
+    const browser = (await (this.launcher['connect'] as any)(
+      ...args
+    )) as pw.Browser
+
+    await this.plugins.dispatchBlocking('onBrowser', browser)
+    await this._bindBrowserEvents(browser)
+    await this.plugins.dispatchBlocking('afterConnect', browser)
+    return browser
+  }
+
+  async connectOverCDP(
+    wsEndpointOrOptions:
+      | string
+      | (pw.ConnectOverCDPOptions & { endpointURL?: string }),
+    wsOptions: pw.ConnectOverCDPOptions = {}
+  ): ReturnType<PlaywrightBrowserLauncher['connectOverCDP']> {
+    if (!this.launcher.connectOverCDP) {
+      throw new Error(`Launcher does not implement 'connectOverCDP'`)
+    }
+    this.plugins.prepare()
+
+    // Playwright currently supports two function signatures for .connectOverCDP
+    let options: pw.ConnectOverCDPOptions & { endpointURL?: string } = {}
+    let wsEndpointAsString = false
+    if (typeof wsEndpointOrOptions === 'object') {
+      options = { ...wsEndpointOrOptions, ...wsOptions }
+    } else {
+      wsEndpointAsString = true
+      options = { endpointURL: wsEndpointOrOptions, ...wsOptions }
+    }
+    debug('connectOverCDP'), options
+
+    // Give plugins the chance to modify the options before launch/connect
+    options =
+      (await this.plugins.dispatchBlocking('beforeConnect', options)) || options
+
+    // Follow call signature of end user
+    const args: any[] = []
+    const endpointURL = options.endpointURL
+    if (wsEndpointAsString) {
+      delete options.endpointURL
+      args.push(endpointURL, options)
+    } else {
+      args.push(options)
+    }
+
+    const browser = (await (this.launcher['connectOverCDP'] as any)(
+      ...args
+    )) as pw.Browser
+
+    await this.plugins.dispatchBlocking('onBrowser', browser)
+    await this._bindBrowserEvents(browser)
+    await this.plugins.dispatchBlocking('afterConnect', browser)
+    return browser
+  }
+
+  protected async _bindBrowserContextEvents(
+    context: pw.BrowserContext,
+    contextOptions?: pw.BrowserContextOptions
+  ) {
+    debug('_bindBrowserContextEvents')
+    this.plugins.dispatch('onContextCreated', context, contextOptions)
+
+    // Make sure things like `addInitScript` show an effect on the very first page as well
+    context.newPage = ((originalMethod, ctx) => {
+      return async () => {
+        const page = await originalMethod.call(ctx)
+        await page.goto('about:blank')
+        return page
+      }
+    })(context.newPage, context)
+
+    context.on('close', () => {
+      // When using `launchPersistentContext` context closing is the same as browser closing
+      if (!context.browser()) {
+        this.plugins.dispatch('onDisconnected')
+      }
+    })
+    context.on('page', page => {
+      this.plugins.dispatch('onPageCreated', page)
+      page.on('close', () => {
+        this.plugins.dispatch('onPageClose', page)
+      })
+    })
+  }
+
+  protected async _bindBrowserEvents(browser: pw.Browser) {
+    debug('_bindPlaywrightBrowserEvents')
+
+    browser.on('disconnected', () => {
+      this.plugins.dispatch('onDisconnected', browser)
+    })
+
+    // Note: `browser.newPage` will implicitly call `browser.newContext` as well
+    browser.newContext = ((originalMethod, ctx) => {
+      return async (options: pw.BrowserContextOptions = {}) => {
+        const contextOptions: pw.BrowserContextOptions =
+          (await this.plugins.dispatchBlocking(
+            'beforeContext',
+            options,
+            browser
+          )) || options
+        const context = await originalMethod.call(ctx, contextOptions)
+        this._bindBrowserContextEvents(context, contextOptions)
+        return context
+      }
+    })(browser.newContext, browser)
+  }
+}
+
+/**
+ * PlaywrightExtra class with additional launcher methods.
+ *
+ * Augments the class with an instance proxy to pass on methods that are not augmented to the original target.
+ *
+ */
+export const PlaywrightExtra = new Proxy(PlaywrightExtraClass, {
+  construct(classTarget, args) {
+    debug(`create instance of ${classTarget.name}`)
+    const result = Reflect.construct(classTarget, args) as PlaywrightExtraClass
+    return new Proxy(result, {
+      get(target, prop) {
+        if (prop in target) {
+          return Reflect.get(target, prop)
+        }
+        debug('proxying property to original launcher: ', prop)
+        return Reflect.get(target.launcher, prop)
+      }
+    })
+  }
+})

--- a/packages/playwright-extra/src/helper/loader.ts
+++ b/packages/playwright-extra/src/helper/loader.ts
@@ -1,0 +1,84 @@
+import type * as pw from 'playwright-core'
+
+/** Node.js module loader helper */
+export class Loader<TargetModule> {
+  constructor(public moduleName: string, public packageNames: string[]) {}
+
+  /**
+   * Lazy load a top level export from another module by wrapping it in a JS proxy.
+   *
+   * This allows us to re-export e.g. `devices` from `playwright` while redirecting direct calls
+   * to it to the module version the user has installed, rather than shipping with a hardcoded version.
+   *
+   * If we don't do this and the user doesn't have the target module installed we'd throw immediately when our code is imported.
+   *
+   * We use a "super" Proxy defining all traps, so calls like `Object.keys(playwright.devices).length` will return the correct value.
+   */
+  public lazyloadExportOrDie<T extends keyof TargetModule>(exportName: T) {
+    const that = this
+    const trapHandler = Object.fromEntries(
+      Object.getOwnPropertyNames(Reflect).map((name: any) => [
+        name,
+        function (target: any, ...args: any[]) {
+          const moduleExport = that.loadModuleOrDie()[exportName]
+          const customTarget = moduleExport as any
+          const result = ((Reflect as any)[name] as any)(
+            customTarget || target,
+            ...args
+          )
+          return result
+        }
+      ])
+    )
+    return new Proxy({}, trapHandler) as TargetModule[T]
+  }
+
+  /** Load the module if possible */
+  public loadModule() {
+    return requirePackages<TargetModule>(this.packageNames)
+  }
+
+  /** Load the module if possible or throw */
+  public loadModuleOrDie(): TargetModule {
+    const module = requirePackages<TargetModule>(this.packageNames)
+    if (module) {
+      return module
+    }
+    throw this.requireError
+  }
+
+  public get requireError() {
+    const moduleNamePretty =
+      this.moduleName.charAt(0).toUpperCase() + this.moduleName.slice(1)
+    return new Error(`
+  ${moduleNamePretty} is missing. :-)
+
+  I've tried loading ${this.packageNames
+    .map(p => `"${p}"`)
+    .join(', ')} - no luck.
+
+  Make sure you install one of those packages or use the named 'addExtra' export,
+  to patch a specific (and maybe non-standard) implementation of ${moduleNamePretty}.
+
+  To get the latest stable version of ${moduleNamePretty} run:
+  'yarn add ${this.moduleName}' or 'npm i ${this.moduleName}'
+  `)
+  }
+}
+
+export function requirePackages<TargetModule = any>(packageNames: string[]) {
+  for (const name of packageNames) {
+    try {
+      return require(name) as TargetModule
+    } catch (_) {
+      continue // noop
+    }
+  }
+  return
+}
+
+/** Playwright specific module loader */
+export const playwrightLoader = new Loader<typeof pw>('playwright', [
+  'playwright-core',
+  'playwright'
+])

--- a/packages/playwright-extra/src/index.ts
+++ b/packages/playwright-extra/src/index.ts
@@ -1,0 +1,121 @@
+import type * as pw from 'playwright-core'
+
+import { PlaywrightExtra, PlaywrightExtraClass } from './extra'
+import { PluginList } from './plugins'
+import { playwrightLoader as loader } from './helper/loader'
+
+export { PlaywrightExtra, PlaywrightExtraClass } from './extra'
+export { PluginList } from './plugins'
+
+/** A playwright browser launcher */
+export type PlaywrightBrowserLauncher = pw.BrowserType<{}>
+/** A playwright browser launcher with plugin functionality */
+export type AugmentedBrowserLauncher = PlaywrightExtraClass &
+  PlaywrightBrowserLauncher
+
+/**
+ * The minimum shape we expect from a playwright compatible launcher object.
+ * We intentionally keep this not strict so other custom or compatible launchers can be used.
+ */
+export interface PlaywrightCompatibleLauncher {
+  connect(...args: any[]): Promise<any>
+  launch(...args: any[]): Promise<any>
+}
+
+/** Our custom module exports */
+interface ExtraModuleExports {
+  PlaywrightExtra: typeof PlaywrightExtra
+  PlaywrightExtraClass: typeof PlaywrightExtraClass
+  PluginList: typeof PluginList
+  addExtra: typeof addExtra
+  chromium: AugmentedBrowserLauncher
+  firefox: AugmentedBrowserLauncher
+  webkit: AugmentedBrowserLauncher
+}
+
+/** Vanilla playwright module exports */
+type PlaywrightModuleExports = typeof pw
+
+/**
+ * Augment the provided Playwright browser launcher with plugin functionality.
+ *
+ * Using `addExtra` will always create a fresh PlaywrightExtra instance.
+ *
+ * @example
+ * import playwright from 'playwright'
+ * import { addExtra } from 'playwright-extra'
+ *
+ * const chromium = addExtra(playwright.chromium)
+ * chromium.use(plugin)
+ *
+ * @param launcher - Playwright (or compatible) browser launcher
+ */
+export const addExtra = <Launcher extends PlaywrightCompatibleLauncher>(
+  launcher?: Launcher
+) => new PlaywrightExtra(launcher) as PlaywrightExtraClass & Launcher
+
+/**
+ * This object can be used to launch or connect to Chromium with plugin functionality.
+ *
+ * This default export will behave exactly the same as the regular playwright
+ * (just with extra plugin functionality) and can be used as a drop-in replacement.
+ *
+ * Behind the scenes it will try to require either the `playwright-core`
+ * or `playwright` module from the installed dependencies.
+ *
+ * @note
+ * Due to Node.js import caching this will result in a single
+ * PlaywrightExtra instance, even when used in different files. If you need multiple
+ * instances with different plugins please use `addExtra`.
+ *
+ * @example
+ * // javascript import
+ * const { chromium } = require('playwright-extra')
+ *
+ * // typescript/es6 module import
+ * import { chromium } from 'playwright-extra'
+ *
+ * // Add plugins
+ * chromium.use(...)
+ */
+export const chromium = addExtra((loader.loadModule() || {}).chromium)
+/**
+ * This object can be used to launch or connect to Firefox with plugin functionality
+ * @note This export will always return the same instance, if you wish to use multiple instances with different plugins use `addExtra`
+ */
+export const firefox = addExtra((loader.loadModule() || {}).firefox)
+/**
+ * This object can be used to launch or connect to Webkit with plugin functionality
+ * @note This export will always return the same instance, if you wish to use multiple instances with different plugins use `addExtra`
+ */
+export const webkit = addExtra((loader.loadModule() || {}).webkit)
+
+// Other playwright module exports we simply re-export with lazy loading
+export const _android = loader.lazyloadExportOrDie('_android')
+export const _electron = loader.lazyloadExportOrDie('_electron')
+export const request = loader.lazyloadExportOrDie('request')
+export const selectors = loader.lazyloadExportOrDie('selectors')
+export const devices = loader.lazyloadExportOrDie('devices')
+export const errors = loader.lazyloadExportOrDie('errors')
+
+/** Playwright with plugin functionality */
+const moduleExports: ExtraModuleExports & PlaywrightModuleExports = {
+  // custom exports
+  PlaywrightExtra,
+  PlaywrightExtraClass,
+  PluginList,
+  addExtra,
+  chromium,
+  firefox,
+  webkit,
+
+  // vanilla exports
+  _android,
+  _electron,
+  request,
+  selectors,
+  devices,
+  errors
+}
+
+export default moduleExports

--- a/packages/playwright-extra/src/plugins.ts
+++ b/packages/playwright-extra/src/plugins.ts
@@ -1,0 +1,412 @@
+import Debug from 'debug'
+const debug = Debug('playwright-extra:plugins')
+
+import {
+  Plugin,
+  PluginMethodName,
+  PluginMethodFn,
+  PluginModule,
+  CompatiblePluginModule
+} from './types'
+
+import { requirePackages } from './helper/loader'
+import { addPuppeteerCompat } from './puppeteer-compatiblity-shim'
+
+export class PluginList {
+  private readonly _plugins: Plugin[] = []
+  private readonly _dependencyDefaults: Map<string, any> = new Map()
+  private readonly _dependencyResolution: Map<string, CompatiblePluginModule> =
+    new Map()
+
+  constructor() {}
+
+  /**
+   * Get a list of all registered plugins.
+   */
+  public get list() {
+    return this._plugins
+  }
+
+  /**
+   * Get the names of all registered plugins.
+   */
+  public get names() {
+    return this._plugins.map(p => p.name)
+  }
+
+  /**
+   * Add a new plugin to the list (after checking if it's well-formed).
+   *
+   * @param plugin
+   * @internal
+   */
+  public add(plugin: Plugin) {
+    if (!this.isValidPluginInstance(plugin)) {
+      return false
+    }
+    if (!!plugin.onPluginRegistered) {
+      plugin.onPluginRegistered({ framework: 'playwright' })
+    }
+    // PuppeteerExtraPlugin: Populate `_childClassMembers` list containing methods defined by the plugin
+    if (!!plugin._registerChildClassMembers) {
+      plugin._registerChildClassMembers(Object.getPrototypeOf(plugin))
+    }
+    if (plugin.requirements?.has('dataFromPlugins')) {
+      plugin.getDataFromPlugins = this.getData.bind(this)
+    }
+    this._plugins.push(plugin)
+    return true
+  }
+
+  /** Check if the shape of a plugin is correct or warn */
+  protected isValidPluginInstance(plugin: Plugin) {
+    if (
+      !plugin ||
+      typeof plugin !== 'object' ||
+      !plugin._isPuppeteerExtraPlugin
+    ) {
+      console.error(
+        `Warning: Plugin is not derived from PuppeteerExtraPlugin, ignoring.`,
+        plugin
+      )
+      return false
+    }
+    if (!plugin.name) {
+      console.error(
+        `Warning: Plugin with no name registering, ignoring.`,
+        plugin
+      )
+      return false
+    }
+    return true
+  }
+
+  /** Error callback in case calling a plugin method throws an error. Can be overwritten. */
+  public onPluginError(plugin: Plugin, method: PluginMethodName, err: Error) {
+    console.warn(
+      `An error occured while executing "${method}" in plugin "${plugin.name}":`,
+      err
+    )
+  }
+
+  /**
+   * Define default values for plugins implicitly required through the `dependencies` plugin stanza.
+   *
+   * @param dependencyPath - The string by which the dependency is listed (not the plugin name)
+   *
+   * @example
+   * chromium.use(stealth)
+   * chromium.plugins.setDependencyDefaults('stealth/evasions/webgl.vendor', { vendor: 'Bob', renderer: 'Alice' })
+   */
+  public setDependencyDefaults(dependencyPath: string, opts: any) {
+    this._dependencyDefaults.set(dependencyPath, opts)
+    return this
+  }
+
+  /**
+   * Define custom plugin modules for plugins implicitly required through the `dependencies` plugin stanza.
+   *
+   * Using this will prevent dynamic imports from being used, which JS bundlers often have issues with.
+   *
+   * @example
+   * chromium.use(stealth)
+   * chromium.plugins.setDependencyResolution('stealth/evasions/webgl.vendor', VendorPlugin)
+   */
+  public setDependencyResolution(
+    dependencyPath: string,
+    pluginModule: CompatiblePluginModule
+  ) {
+    this._dependencyResolution.set(dependencyPath, pluginModule)
+    return this
+  }
+
+  /**
+   * Prepare plugins to be used (resolve dependencies, ordering)
+   * @internal
+   */
+  public prepare() {
+    this.resolveDependencies()
+    this.order()
+  }
+
+  /** Return all plugins using the supplied method */
+  protected filterByMethod(methodName: PluginMethodName) {
+    return this._plugins.filter(plugin => {
+      // PuppeteerExtraPlugin: The base class will already define all methods, hence we need to do a different check
+      if (
+        !!plugin._childClassMembers &&
+        Array.isArray(plugin._childClassMembers)
+      ) {
+        return plugin._childClassMembers.includes(methodName)
+      }
+      return methodName in plugin
+    })
+  }
+
+  /** Conditionally add puppeteer compatibility to values provided to the plugins */
+  protected _addPuppeteerCompatIfNeeded<TMethod extends PluginMethodName>(
+    plugin: Plugin,
+    method: TMethod,
+    args: Parameters<PluginMethodFn<TMethod>>
+  ) {
+    const canUseShim = plugin._isPuppeteerExtraPlugin && !plugin.noPuppeteerShim
+    const methodWhitelist: PluginMethodName[] = [
+      'onBrowser',
+      'onPageCreated',
+      'onPageClose',
+      'afterConnect',
+      'afterLaunch'
+    ]
+    const shouldUseShim = methodWhitelist.includes(method)
+    if (!canUseShim || !shouldUseShim) {
+      return args
+    }
+    debug('add puppeteer compatibility', plugin.name, method)
+    return [...args.map(arg => addPuppeteerCompat(arg as any))] as Parameters<
+      PluginMethodFn<TMethod>
+    >
+  }
+
+  /**
+   * Dispatch plugin lifecycle events in a typesafe way.
+   * Only Plugins that expose the supplied property will be called.
+   *
+   * Will not await results to dispatch events as fast as possible to all plugins.
+   *
+   * @param method - The lifecycle method name
+   * @param args - Optional: Any arguments to be supplied to the plugin methods
+   * @internal
+   */
+  public dispatch<TMethod extends PluginMethodName>(
+    method: TMethod,
+    ...args: Parameters<PluginMethodFn<TMethod>>
+  ): void {
+    const plugins = this.filterByMethod(method)
+    debug('dispatch', method, {
+      all: this._plugins.length,
+      filteredByMethod: plugins.length
+    })
+    for (const plugin of plugins) {
+      try {
+        args = this._addPuppeteerCompatIfNeeded.bind(this)(plugin, method, args)
+        const fnType = plugin[method]?.constructor?.name
+        debug('dispatch to plugin', {
+          plugin: plugin.name,
+          method,
+          fnType
+        })
+        if (fnType === 'AsyncFunction') {
+          ;(plugin[method] as any)(...args).catch((err: any) =>
+            this.onPluginError(plugin, method, err)
+          )
+        } else {
+          ;(plugin[method] as any)(...args)
+        }
+      } catch (err) {
+        this.onPluginError(plugin, method, err as any)
+      }
+    }
+  }
+
+  /**
+   * Dispatch plugin lifecycle events in a typesafe way.
+   * Only Plugins that expose the supplied property will be called.
+   *
+   * Can also be used to get a definite return value after passing it to plugins:
+   * Calls plugins sequentially and passes on a value (waterfall style).
+   *
+   * The plugins can either modify the value or return an updated one.
+   * Will return the latest, updated value which ran through all plugins.
+   *
+   * By convention only the first argument will be used as the updated value.
+   *
+   * @param method - The lifecycle method name
+   * @param args - Optional: Any arguments to be supplied to the plugin methods
+   * @internal
+   */
+  public async dispatchBlocking<TMethod extends PluginMethodName>(
+    method: TMethod,
+    ...args: Parameters<PluginMethodFn<TMethod>>
+  ): Promise<ReturnType<PluginMethodFn<TMethod>>> {
+    const plugins = this.filterByMethod(method)
+    debug('dispatchBlocking', method, {
+      all: this._plugins.length,
+      filteredByMethod: plugins.length
+    })
+
+    let retValue: any = null
+    for (const plugin of plugins) {
+      try {
+        args = this._addPuppeteerCompatIfNeeded.bind(this)(plugin, method, args)
+        retValue = await (plugin[method] as any)(...args)
+        // In case we got a return value use that as new first argument for followup function calls
+        if (retValue !== undefined) {
+          args[0] = retValue
+        }
+      } catch (err) {
+        this.onPluginError(plugin, method, err as any)
+        return retValue
+      }
+    }
+    return retValue
+  }
+
+  /**
+   * Order plugins that have expressed a special placement requirement.
+   *
+   * This is useful/necessary for e.g. plugins that depend on the data from other plugins.
+   *
+   * @private
+   */
+  protected order() {
+    debug('order:before', this.names)
+    const runLast = this._plugins
+      .filter(p => p.requirements?.has('runLast'))
+      .map(p => p.name)
+    for (const name of runLast) {
+      const index = this._plugins.findIndex(p => p.name === name)
+      this._plugins.push(this._plugins.splice(index, 1)[0])
+    }
+    debug('order:after', this.names)
+  }
+
+  /**
+   * Collects the exposed `data` property of all registered plugins.
+   * Will be reduced/flattened to a single array.
+   *
+   * Can be accessed by plugins that listed the `dataFromPlugins` requirement.
+   *
+   * Implemented mainly for plugins that need data from other plugins (e.g. `user-preferences`).
+   *
+   * @see [PuppeteerExtraPlugin]/data
+   * @param name - Filter data by optional name
+   *
+   * @private
+   */
+  protected getData(name?: string) {
+    const data = this._plugins
+      .filter((p: any) => !!p.data)
+      .map((p: any) => (Array.isArray(p.data) ? p.data : [p.data]))
+      .reduce((acc, arr) => [...acc, ...arr], [])
+    return name ? data.filter((d: any) => d.name === name) : data
+  }
+
+  /**
+   * Handle `plugins` stanza (already instantiated plugins that don't require dynamic imports)
+   */
+  protected resolvePluginsStanza() {
+    debug('resolvePluginsStanza')
+    const pluginNames = new Set(this.names)
+    this._plugins
+      .filter(p => !!p.plugins && p.plugins.length)
+      .filter(p => !pluginNames.has(p.name)) // TBD: Do we want to filter out existing?
+      .forEach(parent => {
+        ;(parent.plugins || []).forEach(p => {
+          debug(parent.name, 'adding missing plugin', p.name)
+          this.add(p as Plugin)
+        })
+      })
+  }
+
+  /**
+   * Handle `dependencies` stanza (which requires dynamic imports)
+   *
+   * Plugins can define `dependencies` as a Set or Array of dependency paths, or a Map with additional opts
+   *
+   * @note
+   * - The default opts for implicit dependencies can be defined using `setDependencyDefaults()`
+   * - Dynamic imports can be avoided by providing plugin modules with `setDependencyResolution()`
+   */
+  protected resolveDependenciesStanza() {
+    debug('resolveDependenciesStanza')
+
+    /** Attempt to dynamically require a plugin module */
+    const requireDependencyOrDie = (
+      parentName: string,
+      dependencyPath: string
+    ) => {
+      // If the user provided the plugin module already we use that
+      if (this._dependencyResolution.has(dependencyPath)) {
+        return this._dependencyResolution.get(dependencyPath) as PluginModule
+      }
+
+      const possiblePrefixes = ['puppeteer-extra-plugin-'] // could be extended later
+      const isAlreadyPrefixed = possiblePrefixes.some(prefix =>
+        dependencyPath.startsWith(prefix)
+      )
+      const packagePaths: string[] = []
+      // If the dependency is not already prefixed we attempt to require all possible combinations to find one that works
+      if (!isAlreadyPrefixed) {
+        packagePaths.push(
+          ...possiblePrefixes.map(prefix => prefix + dependencyPath)
+        )
+      }
+      // We always attempt to require the path verbatim (as a last resort)
+      packagePaths.push(dependencyPath)
+      const pluginModule = requirePackages<PluginModule>(packagePaths)
+      if (pluginModule) {
+        return pluginModule
+      }
+
+      const explanation = `
+The plugin '${parentName}' listed '${dependencyPath}' as dependency,
+which could not be found. Please install it:
+
+${packagePaths
+  .map(packagePath => `yarn add ${packagePath.split('/')[0]}`)
+  .join(`\n or:\n`)}
+
+Note: You don't need to require the plugin yourself,
+unless you want to modify it's default settings.
+
+If your bundler has issues with dynamic imports take a look at '.plugins.setDependencyResolution()'.
+      `
+      console.warn(explanation)
+      throw new Error('Plugin dependency not found')
+    }
+
+    const existingPluginNames = new Set(this.names)
+    const recursivelyLoadMissingDependencies = ({
+      name: parentName,
+      dependencies
+    }: Plugin): any => {
+      if (!dependencies) {
+        return
+      }
+      const processDependency = (dependencyPath: string, opts?: any) => {
+        const pluginModule = requireDependencyOrDie(parentName, dependencyPath)
+        opts = opts || this._dependencyDefaults.get(dependencyPath) || {}
+        const plugin = pluginModule(opts)
+        if (existingPluginNames.has(plugin.name)) {
+          debug(parentName, '=> dependency already exists:', plugin.name)
+          return
+        }
+        existingPluginNames.add(plugin.name)
+        debug(parentName, '=> adding new dependency:', plugin.name, opts)
+        this.add(plugin)
+        return recursivelyLoadMissingDependencies(plugin)
+      }
+
+      if (dependencies instanceof Set || Array.isArray(dependencies)) {
+        return [...dependencies].forEach(dependencyPath =>
+          processDependency(dependencyPath)
+        )
+      }
+      if (dependencies instanceof Map) {
+        // Note: `k,v => v,k` (Map + forEach will reverse the order)
+        return dependencies.forEach((v, k) => processDependency(k, v))
+      }
+    }
+    this.list.forEach(recursivelyLoadMissingDependencies)
+  }
+
+  /**
+   * Lightweight plugin dependency management to require plugins and code mods on demand.
+   * @private
+   */
+  protected resolveDependencies() {
+    debug('resolveDependencies')
+    this.resolvePluginsStanza()
+    this.resolveDependenciesStanza()
+  }
+}

--- a/packages/playwright-extra/src/puppeteer-compatiblity-shim/index.ts
+++ b/packages/playwright-extra/src/puppeteer-compatiblity-shim/index.ts
@@ -1,0 +1,224 @@
+import Debug from 'debug'
+const debug = Debug('playwright-extra:puppeteer-compat')
+
+import type * as pw from 'playwright-core'
+
+export type PlaywrightObject = pw.Page | pw.Frame | pw.Browser
+
+export interface PuppeteerBrowserShim {
+  isCompatShim?: boolean
+  isPlaywright?: boolean
+  pages?: pw.BrowserContext['pages']
+  userAgent: () => Promise<'string'>
+}
+
+export interface PuppeteerPageShim {
+  isCompatShim?: boolean
+  isPlaywright?: boolean
+  browser?: () => pw.Browser
+  evaluateOnNewDocument?: pw.Page['addInitScript']
+  _client: () => pw.CDPSession
+}
+
+export const isPlaywrightPage = (obj: unknown): obj is pw.Page => {
+  return 'unroute' in (obj as pw.Page)
+}
+export const isPlaywrightFrame = (obj: unknown): obj is pw.Frame => {
+  return ['parentFrame', 'frameLocator'].every(x => x in (obj as pw.Frame))
+}
+export const isPlaywrightBrowser = (obj: unknown): obj is pw.Browser => {
+  return 'newContext' in (obj as pw.Browser)
+}
+export const isPuppeteerCompat = (obj?: unknown): obj is PlaywrightObject => {
+  return !!obj && typeof obj === 'object' && !!(obj as any).isCompatShim
+}
+
+const cache = {
+  objectToShim: new Map<PlaywrightObject, PlaywrightObject>(),
+  cdpSession: {
+    page: new Map<pw.Page | pw.Frame, pw.CDPSession>(),
+    browser: new Map<pw.Browser, pw.CDPSession>()
+  }
+}
+
+/** Augment a Playwright object with compatibility with certain Puppeteer methods */
+export function addPuppeteerCompat<
+  Input extends pw.Page | pw.Frame | pw.Browser | null
+>(object: Input): Input {
+  if (!object || typeof object !== 'object') {
+    return object
+  }
+  if (cache.objectToShim.has(object)) {
+    return cache.objectToShim.get(object) as Input
+  }
+  if (isPuppeteerCompat(object)) {
+    return object
+  }
+  debug('addPuppeteerCompat', cache.objectToShim.size)
+  if (isPlaywrightPage(object) || isPlaywrightFrame(object)) {
+    const shim = createPageShim(object)
+    cache.objectToShim.set(object, shim)
+    return shim as Input
+  }
+  if (isPlaywrightBrowser(object)) {
+    const shim = createBrowserShim(object)
+    cache.objectToShim.set(object, shim)
+    return shim as Input
+  }
+  debug('Received unknown object:', Reflect.ownKeys(object))
+  return object
+}
+
+// Only chromium browsers support CDP
+const dummyCDPClient = {
+  send: async (...args: any[]) => {
+    debug('dummy CDP client called', 'send', args)
+  },
+  on: (...args: any[]) => {
+    debug('dummy CDP client called', 'on', args)
+  }
+} as pw.CDPSession
+
+export async function getPageCDPSession(page: pw.Page | pw.Frame) {
+  let session = cache.cdpSession.page.get(page)
+  if (session) {
+    debug('getPageCDPSession: use existing')
+    return session
+  }
+  debug('getPageCDPSession: use new')
+  const context = isPlaywrightFrame(page)
+    ? page.page().context()
+    : page.context()
+  try {
+    session = await context.newCDPSession(page)
+    cache.cdpSession.page.set(page, session)
+    return session
+  } catch (err: any) {
+    debug('getPageCDPSession: error while creating session:', err.message)
+    debug(
+      'getPageCDPSession: Unable create CDP session (most likely a different browser than chromium) - returning a dummy'
+    )
+  }
+  return dummyCDPClient
+}
+
+export async function getBrowserCDPSession(browser: pw.Browser) {
+  let session = cache.cdpSession.browser.get(browser)
+  if (session) {
+    debug('getBrowserCDPSession: use existing')
+    return session
+  }
+  debug('getBrowserCDPSession: use new')
+  try {
+    session = await browser.newBrowserCDPSession()
+    cache.cdpSession.browser.set(browser, session)
+    return session
+  } catch (err: any) {
+    debug('getBrowserCDPSession: error while creating session:', err.message)
+    debug(
+      'getBrowserCDPSession: Unable create CDP session (most likely a different browser than chromium) - returning a dummy'
+    )
+  }
+  return dummyCDPClient
+}
+
+export function createPageShim(page: pw.Page | pw.Frame) {
+  const objId = Math.random().toString(36).substring(2, 7)
+  const shim = new Proxy(page, {
+    get(target, prop) {
+      if (prop === 'isCompatShim' || prop === 'isPlaywright') {
+        return true
+      }
+      debug('page - get', objId, prop)
+      if (prop === '_client') {
+        return () => ({
+          send: async (method: string, params: any) => {
+            const session = await getPageCDPSession(page)
+            return await session.send(method as any, params)
+          },
+          on: (event: string, listener: any) => {
+            getPageCDPSession(page).then(session => {
+              session.on(event as any, listener)
+            })
+          }
+        })
+      }
+      if (prop === 'setBypassCSP') {
+        return async (enabled: boolean) => {
+          const session = await getPageCDPSession(page)
+          return await session.send('Page.setBypassCSP', {
+            enabled
+          })
+        }
+      }
+      if (prop === 'setUserAgent') {
+        return async (userAgent: string, userAgentMetadata?: any) => {
+          const session = await getPageCDPSession(page)
+          return await session.send('Emulation.setUserAgentOverride', {
+            userAgent,
+            userAgentMetadata
+          })
+        }
+      }
+      if (prop === 'browser') {
+        if (isPlaywrightPage(page)) {
+          return () => {
+            let browser = page.context().browser()
+            if (!browser) {
+              debug(
+                'page.browser() - not available, most likely due to launchPersistentContext'
+              )
+              // Use a page shim as quick drop-in (so browser.userAgent() still works)
+              browser = page as any
+            }
+            return addPuppeteerCompat(browser)
+          }
+        }
+      }
+      if (prop === 'evaluateOnNewDocument') {
+        if (isPlaywrightPage(page)) {
+          return async function (pageFunction: any | string, ...args: any[]) {
+            return await page.addInitScript(pageFunction, args[0])
+          }
+        }
+      }
+      // Only relevant when page is being used a pseudo stand-in for the browser object (launchPersistentContext)
+      if (prop === 'userAgent') {
+        return async (enabled: boolean) => {
+          const session = await getPageCDPSession(page)
+          const data = await session.send('Browser.getVersion')
+          return data.userAgent
+        }
+      }
+      return Reflect.get(target, prop)
+    }
+  })
+  return shim
+}
+
+export function createBrowserShim(browser: pw.Browser) {
+  const objId = Math.random().toString(36).substring(2, 7)
+  const shim = new Proxy(browser, {
+    get(target, prop) {
+      if (prop === 'isCompatShim' || prop === 'isPlaywright') {
+        return true
+      }
+      debug('browser - get', objId, prop)
+      if (prop === 'pages') {
+        return () =>
+          browser
+            .contexts()
+            .flatMap(c => c.pages().map(page => addPuppeteerCompat(page)))
+      }
+      if (prop === 'userAgent') {
+        return async () => {
+          const session = await getBrowserCDPSession(browser)
+          const data = await session.send('Browser.getVersion')
+          return data.userAgent
+        }
+      }
+      return Reflect.get(target, prop)
+    }
+  })
+  return shim
+}

--- a/packages/playwright-extra/src/puppeteer-compatiblity-shim/playwright-shim.d.ts
+++ b/packages/playwright-extra/src/puppeteer-compatiblity-shim/playwright-shim.d.ts
@@ -1,0 +1,11 @@
+// Playwright objects extended with puppeteer compatiblity shims
+
+import type {} from 'playwright-core'
+
+import type { PuppeteerPageShim, PuppeteerBrowserShim } from '.'
+
+declare module 'playwright-core' {
+  interface Page extends PuppeteerPageShim {}
+  interface Frame extends PuppeteerPageShim {}
+  interface Browser extends PuppeteerBrowserShim {}
+}

--- a/packages/playwright-extra/src/types/index.ts
+++ b/packages/playwright-extra/src/types/index.ts
@@ -1,0 +1,125 @@
+import type * as pw from 'playwright-core'
+
+type PropType<TObj, TProp extends keyof TObj> = TObj[TProp]
+type PluginEnv = { framework: 'playwright' }
+
+/** Strongly typed plugin lifecycle events for internal use */
+export abstract class PluginLifecycleMethods {
+  async onPluginRegistered(env?: PluginEnv): Promise<void> {}
+  async beforeLaunch(
+    options: pw.LaunchOptions
+  ): Promise<pw.LaunchOptions | void> {}
+  async afterLaunch(browserOrContext?: pw.Browser | pw.BrowserContext) {}
+  async beforeConnect(
+    options: pw.ConnectOptions
+  ): Promise<pw.ConnectOptions | void> {}
+  async afterConnect(browser: pw.Browser) {}
+  async onBrowser(browser: pw.Browser) {}
+  async onPageCreated(page: pw.Page) {}
+  async onPageClose(page: pw.Page) {}
+  async onDisconnected(browser?: pw.Browser) {}
+  // Playwright only at the moment
+  async beforeContext(
+    options?: pw.BrowserContextOptions,
+    browser?: pw.Browser
+  ): Promise<pw.BrowserContextOptions | void> {}
+  async onContextCreated(
+    context?: pw.BrowserContext,
+    options?: pw.BrowserContextOptions
+  ) {}
+}
+
+/** A valid plugin method name */
+export type PluginMethodName = keyof PluginLifecycleMethods
+/** A valid plugin method function */
+export type PluginMethodFn<TName extends PluginMethodName> = PropType<
+  PluginLifecycleMethods,
+  TName
+>
+
+type PluginRequirements = Set<
+  'launch' | 'headful' | 'dataFromPlugins' | 'runLast'
+>
+
+// PuppeteerExtraPlugin only supports Set, the others are future proofing
+type PluginDependencies = Set<string> | Map<string, any> | string[]
+
+interface PluginData {
+  name:
+    | string
+    // below is compat with a previously incorrect typing
+    | {
+        [key: string]: any
+      }
+  value: {
+    [key: string]: any
+  }
+}
+
+export interface CompatiblePluginLifecycleMethods {
+  onPluginRegistered(...any: any[]): Promise<any> | any
+  beforeLaunch(...any: any[]): Promise<any> | any
+  afterLaunch(...any: any[]): Promise<any> | any
+  beforeConnect(...any: any[]): Promise<any> | any
+  afterConnect(...any: any[]): Promise<any> | any
+  onBrowser(...any: any[]): Promise<any> | any
+  onPageCreated(...any: any[]): Promise<any> | any
+  onPageClose(...any: any[]): Promise<any> | any
+  onDisconnected(...any: any[]): Promise<any> | any
+  // Playwright only at the moment
+  beforeContext(...any: any[]): Promise<any> | any
+  onContextCreated(...any: any[]): Promise<any> | any
+}
+
+/**
+ * PuppeteerExtraPlugin interface, strongly typed for internal use
+ * @private
+ */
+export interface PuppeteerExtraPlugin extends Partial<PluginLifecycleMethods> {
+  _isPuppeteerExtraPlugin: boolean
+  name: string
+  /** Disable the puppeteer compatibility shim for this plugin */
+  noPuppeteerShim?: boolean
+  requirements?: PluginRequirements
+  dependencies?: PluginDependencies
+  data?: PluginData[]
+  getDataFromPlugins?(name?: string): void
+  _registerChildClassMembers?(prototype: any): void
+  _childClassMembers?: string[]
+  plugins?: CompatiblePlugin[]
+  // [propName: string]: any
+}
+
+/**
+ * Minimal compatible PuppeteerExtraPlugin interface
+ * @private
+ */
+export interface CompatiblePuppeteerPlugin
+  extends Partial<CompatiblePluginLifecycleMethods> {
+  _isPuppeteerExtraPlugin: boolean
+  name?: string
+}
+// Future proofing
+export interface CompatiblePlaywrightPlugin
+  extends Partial<CompatiblePluginLifecycleMethods> {
+  _isPlaywrightExtraPlugin: boolean
+  name?: string
+}
+// Future proofing
+export interface CompatibleExtraPlugin
+  extends Partial<CompatiblePluginLifecycleMethods> {
+  _isExtraPlugin: boolean
+  name?: string
+}
+
+/**
+ * A compatible plugin
+ */
+export type CompatiblePlugin =
+  | CompatiblePuppeteerPlugin
+  | CompatiblePlaywrightPlugin
+  | CompatibleExtraPlugin
+export type CompatiblePluginModule = (...args: any[]) => CompatiblePlugin
+
+export type Plugin = PuppeteerExtraPlugin
+export type PluginModule = (...args: any[]) => Plugin

--- a/packages/playwright-extra/test/exports.spec.ts
+++ b/packages/playwright-extra/test/exports.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from './fixtures/extra'
+
+test('should export the basic functionality', async ({ playwrightExtra }) => {
+  expect(playwrightExtra.addExtra).toBeDefined()
+  expect(playwrightExtra.chromium).toBeDefined()
+  expect(playwrightExtra.chromium.use).toBeDefined()
+  expect(playwrightExtra.chromium.plugins).toBeDefined()
+  expect(playwrightExtra.chromium.plugins.list).toBeDefined()
+  expect(playwrightExtra.chromium.plugins.names).toBeDefined()
+  expect(playwrightExtra.chromium.plugins.onPluginError).toBeDefined()
+  expect(playwrightExtra.chromium.launch).toBeDefined()
+  expect(playwrightExtra.chromium.launchPersistentContext).toBeDefined()
+  expect(playwrightExtra.chromium.connect).toBeDefined()
+  expect(playwrightExtra.chromium.connectOverCDP).toBeDefined()
+  expect(playwrightExtra.firefox).toBeDefined()
+  expect(playwrightExtra.firefox.use).toBeDefined()
+  expect(playwrightExtra.firefox.launch).toBeDefined()
+  expect(playwrightExtra.firefox.connect).toBeDefined()
+  expect(playwrightExtra.webkit).toBeDefined()
+  expect(playwrightExtra.webkit.use).toBeDefined()
+  expect(playwrightExtra.webkit.launch).toBeDefined()
+  expect(playwrightExtra.webkit.connect).toBeDefined()
+  expect((playwrightExtra as any).nonexistent).toBeUndefined()
+})
+
+test('chromium export should be well formed', async ({ playwrightExtra }) => {
+  const { chromium } = playwrightExtra
+  expect(typeof chromium).toBe('object')
+  expect(typeof chromium.use).toBe('function')
+  expect(typeof chromium.launch).toBe('function')
+  expect(typeof chromium.connect).toBe('function')
+  expect(typeof chromium.name).toBe('function')
+  expect(typeof chromium.name()).toBe('string')
+  expect(chromium.constructor.name).toBe('PlaywrightExtraClass')
+})
+
+test('addExtra export should be well formed', async ({ playwrightExtra }) => {
+  const { addExtra } = playwrightExtra
+  expect(typeof addExtra).toBe('function')
+
+  const launcher = addExtra()
+  expect(typeof launcher).toBe('object')
+  expect(launcher.constructor.name).toBe('PlaywrightExtraClass')
+})
+
+test('should re-export the same additional exports verbatim', async ({
+  playwrightExtra,
+  playwrightVanilla
+}) => {
+  expect(playwrightExtra.errors).toStrictEqual(playwrightVanilla.errors)
+  expect(playwrightExtra.devices).toStrictEqual(playwrightVanilla.devices)
+  expect(playwrightExtra.selectors).toStrictEqual(playwrightVanilla.selectors)
+  expect(playwrightExtra.request).toStrictEqual(playwrightVanilla.request)
+})

--- a/packages/playwright-extra/test/fixtures/dummyplugin.ts
+++ b/packages/playwright-extra/test/fixtures/dummyplugin.ts
@@ -1,0 +1,58 @@
+import { PuppeteerExtraPlugin } from 'puppeteer-extra-plugin'
+
+export class DummyPlugin extends PuppeteerExtraPlugin {
+  public pluginEventList: string[] = []
+  public pluginEventMap: Map<string, any> = new Map()
+
+  constructor(opts = {}) {
+    super(opts)
+  }
+  get name() {
+    return 'dummy'
+  }
+
+  async onPluginRegistered(...args: any[]) {
+    this.pluginEventList.push('onPluginRegistered')
+  }
+  async beforeLaunch(...args: any[]) {
+    this.pluginEventList.push('beforeLaunch')
+  }
+  async afterLaunch(...args: any[]) {
+    this.pluginEventList.push('afterLaunch')
+  }
+  async beforeConnect(...args: any[]) {
+    this.pluginEventList.push('beforeConnect')
+  }
+  async afterConnect(...args: any[]) {
+    this.pluginEventList.push('afterConnect')
+  }
+  async onBrowser(...args: any[]) {
+    this.pluginEventList.push('onBrowser')
+  }
+  async onTargetCreated(...args: any[]) {
+    this.pluginEventList.push('onTargetCreated')
+  }
+  async onPageCreated(...args: any[]) {
+    this.pluginEventList.push('onPageCreated')
+  }
+  async onTargetChanged(...args: any[]) {
+    this.pluginEventList.push('onTargetChanged')
+  }
+  async onTargetDestroyed(...args: any[]) {
+    this.pluginEventList.push('onTargetDestroyed')
+  }
+  async onDisconnected(...args: any[]) {
+    this.pluginEventList.push('onDisconnected')
+  }
+  async onClose(...args: any[]) {
+    this.pluginEventList.push('onClose')
+  }
+
+  // playwright only at the moment
+  async beforeContext(...args: any[]) {
+    this.pluginEventList.push('beforeContext')
+  }
+  async onContextCreated(...args: any[]) {
+    this.pluginEventList.push('onContextCreated')
+  }
+}

--- a/packages/playwright-extra/test/fixtures/extra.ts
+++ b/packages/playwright-extra/test/fixtures/extra.ts
@@ -1,0 +1,80 @@
+// Playwrights test runner is great, originally based on folio (which unfortunately isn't maintained anymore): https://github.com/microsoft/folio
+import { test as base } from '@playwright/test'
+import * as pwTest from '@playwright/test'
+
+import * as pwExtraModule from '../../src'
+import * as pwVanillaModule from 'playwright-core'
+
+type PluginModuleWithOptions = { module: any; opts?: Record<string, any> }
+
+export type ExtraOptions = {}
+
+export type ExtraFixtures = {
+  /** playwright-extra module */
+  playwrightExtra: typeof pwExtraModule
+  /** playwright-core module */
+  playwrightVanilla: typeof pwVanillaModule
+  /** Augmented launcher */
+  extraLauncher: pwExtraModule.AugmentedBrowserLauncher
+}
+
+type WorkerFixtures = {
+  _connectedBrowser: pwTest.Browser | undefined
+  _browserOptions: pwTest.LaunchOptions
+  _artifactsDir: () => string
+  _snapshotSuffix: string
+
+  plugins: PluginModuleWithOptions[]
+}
+
+export const worker = base.extend<{}, WorkerFixtures>({
+  plugins: [[], { option: true, scope: 'worker' as any }],
+
+  browser: async (
+    { playwright, browserName, _connectedBrowser, plugins },
+    use
+  ) => {
+    if (_connectedBrowser) {
+      await use(_connectedBrowser)
+      return
+    }
+
+    if (!['chromium', 'firefox', 'webkit'].includes(browserName))
+      throw new Error(
+        `Unexpected browserName "${browserName}", must be one of "chromium", "firefox" or "webkit"`
+      )
+    const launcher = pwExtraModule.addExtra(playwright[browserName])
+
+    plugins.forEach(({ module: pluginModule, opts }) => {
+      launcher.use(pluginModule(opts))
+    })
+
+    const browser = await launcher.launch()
+    ;(browser as any)._launcher = launcher
+    await use(browser as any)
+    await browser.close()
+  }
+})
+
+// Extend base test by providing "todoPage" and "settingsPage".
+// This new "test" can be used in multiple test files, and each of them will get the fixtures.
+export const test = worker.extend<ExtraOptions & ExtraFixtures>({
+  extraLauncher: async (
+    { plugins, playwrightExtra, playwrightVanilla, browserName },
+    use
+  ) => {
+    const launcher = playwrightExtra.addExtra(playwrightVanilla[browserName])
+    plugins.forEach(({ module: pluginModule, opts }) => {
+      launcher.use(pluginModule(opts))
+    })
+    await use(launcher)
+  },
+  playwrightExtra: async ({}, use) => {
+    await use(pwExtraModule)
+  },
+  playwrightVanilla: async ({}, use) => {
+    await use(pwVanillaModule)
+  }
+})
+
+export { expect } from '@playwright/test'

--- a/packages/playwright-extra/test/playwright.config.ts
+++ b/packages/playwright-extra/test/playwright.config.ts
@@ -5,18 +5,20 @@ const config: PlaywrightTestConfig = {
   workers: 3,
 
   use: {
-    browserName: 'chromium',
-    launchOptions: {
-      chromiumSandbox: process.env.CI ? false : true,
-      args: process.env.CI ? ['--no-sandbox', '--disable-setuid-sandbox'] : []
-    }
+    browserName: 'chromium'
   },
 
   projects: [
     {
       name: 'chromium',
       use: {
-        browserName: 'chromium'
+        browserName: 'chromium',
+        launchOptions: {
+          chromiumSandbox: process.env.CI ? false : true,
+          args: process.env.CI
+            ? ['--no-sandbox', '--disable-setuid-sandbox']
+            : []
+        }
       }
     },
     {
@@ -29,6 +31,7 @@ const config: PlaywrightTestConfig = {
       name: 'webkit',
       use: {
         browserName: 'webkit'
+        // Note: webkit doesn't support --no-sandbox
       }
     }
   ]

--- a/packages/playwright-extra/test/playwright.config.ts
+++ b/packages/playwright-extra/test/playwright.config.ts
@@ -1,0 +1,37 @@
+import { type PlaywrightTestConfig } from '@playwright/test'
+
+const config: PlaywrightTestConfig = {
+  retries: 3,
+  workers: 3,
+
+  use: {
+    browserName: 'chromium',
+    launchOptions: {
+      chromiumSandbox: process.env.CI ? false : true,
+      args: process.env.CI ? ['--no-sandbox', '--disable-setuid-sandbox'] : []
+    }
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        browserName: 'chromium'
+      }
+    },
+    {
+      name: 'firefox',
+      use: {
+        browserName: 'firefox'
+      }
+    },
+    {
+      name: 'webkit',
+      use: {
+        browserName: 'webkit'
+      }
+    }
+  ]
+}
+
+export default config

--- a/packages/playwright-extra/test/plugin-events.spec.ts
+++ b/packages/playwright-extra/test/plugin-events.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from './fixtures/extra'
+
+import { DummyPlugin } from './fixtures/dummyplugin'
+
+test.use({ plugins: [{ module: (opts: any) => new DummyPlugin(opts) }] })
+
+test('emits correct events for launch', async ({ extraLauncher }) => {
+  const browser = await extraLauncher.launch()
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  await page.close()
+  await browser.close()
+
+  const plugin = extraLauncher.plugins.list[0] as unknown as DummyPlugin
+  expect(plugin.pluginEventList).toStrictEqual([
+    'onPluginRegistered',
+    'beforeLaunch',
+    'onBrowser',
+    'afterLaunch',
+    'beforeContext',
+    'onContextCreated',
+    'onPageCreated',
+    'onDisconnected'
+  ])
+})
+
+test('emits correct events for launch without .newContext()', async ({
+  extraLauncher
+}) => {
+  const browser = await extraLauncher.launch()
+  const page = await browser.newPage()
+  await page.close()
+  await browser.close()
+
+  const plugin = extraLauncher.plugins.list[0] as unknown as DummyPlugin
+  expect(plugin.pluginEventList).toStrictEqual([
+    'onPluginRegistered',
+    'beforeLaunch',
+    'onBrowser',
+    'afterLaunch',
+    'beforeContext',
+    'onContextCreated',
+    'onPageCreated',
+    'onDisconnected'
+  ])
+})
+
+test('emits correct events for launchPersistentContext', async ({
+  extraLauncher
+}) => {
+  const context = await extraLauncher.launchPersistentContext('')
+  const page = await context.newPage()
+  await page.close()
+  await context.close()
+
+  const plugin = extraLauncher.plugins.list[0] as unknown as DummyPlugin
+  expect(plugin.pluginEventList).toStrictEqual([
+    'onPluginRegistered',
+    'beforeLaunch',
+    'afterLaunch',
+    'onContextCreated',
+    'onPageCreated',
+    'onDisconnected'
+  ])
+})
+
+test('emits correct events for connect', async ({ extraLauncher }) => {
+  const server = await extraLauncher.launchServer()
+
+  const browser = await extraLauncher.connect(server.wsEndpoint())
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  await page.close()
+  await browser.close()
+  await server.close()
+
+  const plugin = extraLauncher.plugins.list[0] as unknown as DummyPlugin
+  expect(plugin.pluginEventList).toStrictEqual([
+    'onPluginRegistered',
+    'beforeConnect',
+    'onBrowser',
+    'afterConnect',
+    'beforeContext',
+    'onContextCreated',
+    'onPageCreated',
+    'onDisconnected'
+  ])
+})
+
+test('emits correct events for connectOverCDP', async ({
+  extraLauncher,
+  browserName
+}) => {
+  test.skip(browserName !== 'chromium', 'Chromium only')
+
+  const server = await extraLauncher.launchServer({
+    args: ['--remote-debugging-port=9333']
+  })
+
+  const browser = await extraLauncher.connectOverCDP('http://localhost:9333')
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  await page.close()
+  await browser.close()
+  await server.close()
+
+  const plugin = extraLauncher.plugins.list[0] as unknown as DummyPlugin
+  expect(plugin.pluginEventList).toStrictEqual([
+    'onPluginRegistered',
+    'beforeConnect',
+    'onBrowser',
+    'afterConnect',
+    'beforeContext',
+    'onContextCreated',
+    'onPageCreated',
+    'onDisconnected'
+  ])
+})

--- a/packages/playwright-extra/test/puppeteer-plugins/anonymize-ua.spec.ts
+++ b/packages/playwright-extra/test/puppeteer-plugins/anonymize-ua.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '../fixtures/extra'
+
+import AnonymizeUAPlugin from 'puppeteer-extra-plugin-anonymize-ua'
+
+test('puppeteer-extra-plugin-anonymize-ua will remove headless', async ({
+  browserName,
+  extraLauncher,
+  _browserOptions
+}) => {
+  test.skip(browserName !== 'chromium', 'Chromium only')
+
+  const pluginErrors = []
+  extraLauncher.plugins.onPluginError = (plugin, method, err) => {
+    pluginErrors.push(err)
+  }
+
+  extraLauncher.use(AnonymizeUAPlugin())
+  expect(extraLauncher.plugins.list.length).toEqual(1)
+  expect(extraLauncher.plugins.list[0].name).toEqual('anonymize-ua')
+
+  const browser = await extraLauncher.launch(_browserOptions)
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  await page.goto('https://example.com')
+
+  const ua = await page.evaluate(() => navigator.userAgent)
+  expect(ua.includes('Headless')).toBeFalsy()
+  expect(pluginErrors).toStrictEqual([])
+
+  await browser.close()
+})
+
+test('puppeteer-extra-plugin-anonymize-ua will allow a custom UA', async ({
+  browserName,
+  extraLauncher,
+  _browserOptions
+}) => {
+  test.skip(browserName !== 'chromium', 'Chromium only')
+
+  const pluginErrors = []
+  extraLauncher.plugins.onPluginError = (plugin, method, err) => {
+    pluginErrors.push(err)
+  }
+  extraLauncher.use(
+    AnonymizeUAPlugin({
+      customFn: ua => 'MyCoolUserAgent'
+    })
+  )
+  expect(extraLauncher.plugins.list.length).toEqual(1)
+  expect(extraLauncher.plugins.list[0].name).toEqual('anonymize-ua')
+
+  const browser = await extraLauncher.launch(_browserOptions)
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  await page.goto('https://example.com')
+
+  const ua = await page.evaluate(() => navigator.userAgent)
+  expect(ua).toBe('MyCoolUserAgent')
+  expect(pluginErrors).toStrictEqual([])
+
+  await browser.close()
+})

--- a/packages/playwright-extra/test/puppeteer-plugins/recaptcha.spec.ts
+++ b/packages/playwright-extra/test/puppeteer-plugins/recaptcha.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '../fixtures/extra'
+
+import RecaptchaPlugin from 'puppeteer-extra-plugin-recaptcha'
+
+// Supports all browsers
+test('puppeteer-extra-plugin-recaptcha will detect captchas', async ({
+  extraLauncher,
+  _browserOptions
+}) => {
+  const pluginErrors = []
+  extraLauncher.plugins.onPluginError = (plugin, method, err) => {
+    pluginErrors.push(err)
+  }
+
+  const instance = RecaptchaPlugin()
+  extraLauncher.use(instance)
+  expect(extraLauncher.plugins.list.length).toEqual(1)
+  expect(extraLauncher.plugins.list[0].name).toEqual(instance.name)
+
+  const url =
+    'https://berstend.github.io/static/recaptcha/v2-checkbox-auto.html'
+  const browser = await extraLauncher.launch(_browserOptions)
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  await page.goto(url)
+
+  const { captchas, error } = await (page as any).findRecaptchas()
+
+  expect(error).toBeFalsy()
+  expect(captchas).toBeTruthy()
+  expect(captchas.length).toBe(1)
+  const captcha = captchas[0]
+  expect(captcha._vendor).toBe('recaptcha')
+  expect(captcha._type).toBe('checkbox')
+  expect(captcha.url).toBe(url)
+  expect(captcha.id).toBeTruthy()
+  expect(captcha.sitekey).toBeTruthy()
+
+  expect(pluginErrors).toStrictEqual([])
+  await browser.close()
+})
+
+test('puppeteer-extra-plugin-recaptcha will solve captchas', async ({
+  extraLauncher,
+  _browserOptions
+}) => {
+  test.skip(!process.env.TWOCAPTCHA_TOKEN, 'TWOCAPTCHA_TOKEN not set')
+  test.slow()
+
+  const pluginErrors = []
+  extraLauncher.plugins.onPluginError = (plugin, method, err) => {
+    pluginErrors.push(err)
+  }
+
+  const instance = RecaptchaPlugin({
+    provider: {
+      id: '2captcha',
+      token: process.env.TWOCAPTCHA_TOKEN
+    }
+  })
+  extraLauncher.use(instance)
+  expect(extraLauncher.plugins.list.length).toEqual(1)
+  expect(extraLauncher.plugins.list[0].name).toEqual(instance.name)
+
+  const url = 'https://www.google.com/recaptcha/api2/demo'
+  const browser = await extraLauncher.launch(_browserOptions)
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  await page.goto(url, { waitUntil: 'networkidle' })
+
+  const { solved, error } = await (page as any).solveRecaptchas()
+  expect(error).toBeFalsy()
+  expect(solved).toBeTruthy()
+  expect(solved.length).toBe(1)
+
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: 'networkidle' }),
+    page.click(`#recaptcha-demo-submit`)
+  ])
+  const content = await page.content()
+  expect(content).toMatch('Verification Success... Hooray!')
+
+  expect(pluginErrors).toStrictEqual([])
+  await browser.close()
+})

--- a/packages/playwright-extra/test/puppeteer-plugins/stealth.spec.ts
+++ b/packages/playwright-extra/test/puppeteer-plugins/stealth.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '../fixtures/extra'
+
+import StealthPlugin from 'puppeteer-extra-plugin-stealth'
+
+test('puppeteer-extra-plugin-stealth will work', async ({
+  browserName,
+  extraLauncher,
+  _browserOptions
+}) => {
+  test.skip(browserName !== 'chromium', 'Chromium only')
+
+  const pluginErrors = []
+  extraLauncher.plugins.onPluginError = (plugin, method, err) => {
+    pluginErrors.push(err)
+  }
+
+  extraLauncher.use(StealthPlugin())
+  expect(extraLauncher.plugins.list.length).toEqual(1)
+  expect(extraLauncher.plugins.list[0].name).toEqual('stealth')
+
+  extraLauncher.plugins.setDependencyDefaults('stealth/evasions/webgl.vendor', {
+    vendor: 'Bob',
+    renderer: 'Alice'
+  })
+
+  const browser = await extraLauncher.launch(_browserOptions)
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  await page.goto('https://example.com')
+
+  const webgl = await page.evaluate(getWebglUnmasked)
+  expect(webgl).toStrictEqual({ renderer: 'Alice', vendor: 'Bob' })
+
+  expect(pluginErrors).toStrictEqual([])
+
+  await browser.close()
+})
+
+function getWebglUnmasked() {
+  const gl = document.createElement('canvas').getContext('webgl') as any
+  if (!gl) {
+    return {
+      error: 'no webgl'
+    }
+  }
+  const debugInfo = gl.getExtension('WEBGL_debug_renderer_info')
+  if (debugInfo) {
+    return {
+      vendor: gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL),
+      renderer: gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL)
+    }
+  }
+  return {
+    error: 'no WEBGL_debug_renderer_info'
+  }
+}

--- a/packages/playwright-extra/tsconfig.json
+++ b/packages/playwright-extra/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "target": "es2017",
+    "module": "es2015",
+    "moduleResolution": "node",
+    "lib": ["es2015", "es2016", "es2017", "dom"],
+    "sourceMap": true,
+    "declaration": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    "pretty": true,
+    "stripInternal": true,
+    "types": ["node"]
+  },
+  "include": ["./src/**/*.tsx", "./src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "./test/**/*.spec.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2039,6 +2039,14 @@
   dependencies:
     "@octokit/openapi-types" "^10.2.2"
 
+"@playwright/test@^1.23.1":
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.23.1.tgz#209cceb81c579d1cd2835f15c2bb3a8345103d60"
+  integrity sha512-dKplLPSYPZgnsBk1xxOophhpx3ZVg8DveoNJgLPe096lDCfmaIIreLsYF+4hqzy3PG61IP+aEnG5VAOjC3bhbA==
+  dependencies:
+    "@types/node" "*"
+    playwright-core "1.23.1"
+
 "@remusao/guess-url-type@^1.1.2":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@remusao/guess-url-type/-/guess-url-type-1.2.1.tgz#b3e7c32abdf98d0fb4f93cc67cad580b5fe4ba57"
@@ -2099,7 +2107,7 @@
     "@types/filesystem" "*"
     "@types/har-format" "*"
 
-"@types/debug@^4.1.0", "@types/debug@^4.1.5":
+"@types/debug@^4.1.0", "@types/debug@^4.1.5", "@types/debug@^4.1.7":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
   integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
@@ -2188,6 +2196,11 @@
   version "14.17.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.6.tgz#cc61c8361c89e70c468cda464d1fa3dd7e5ebd62"
   integrity sha512-iBxsxU7eswQDGhlr3AiamBxOssaYxbM+NKXVil8jg9yFXvrfEFbDumLD/2dMTB+zYyg7w+Xjt8yuxfdbUHAtcQ==
+
+"@types/node@^18.0.0":
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
+  integrity sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -3781,6 +3794,13 @@ debug@^3.1.0, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -4266,6 +4286,137 @@ es6-promisify@^5.0.0:
   integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
   dependencies:
     es6-promise "^4.0.3"
+
+esbuild-android-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.47.tgz#ef95b42c67bcf4268c869153fa3ad1466c4cea6b"
+  integrity sha512-R13Bd9+tqLVFndncMHssZrPWe6/0Kpv2/dt4aA69soX4PRxlzsVpCvoJeFE8sOEoeVEiBkI0myjlkDodXlHa0g==
+
+esbuild-android-arm64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.47.tgz#4ebd7ce9fb250b4695faa3ee46fd3b0754ecd9e6"
+  integrity sha512-OkwOjj7ts4lBp/TL6hdd8HftIzOy/pdtbrNA4+0oVWgGG64HrdVzAF5gxtJufAPOsEjkyh1oIYvKAUinKKQRSQ==
+
+esbuild-darwin-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.47.tgz#e0da6c244f497192f951807f003f6a423ed23188"
+  integrity sha512-R6oaW0y5/u6Eccti/TS6c/2c1xYTb1izwK3gajJwi4vIfNs1s8B1dQzI1UiC9T61YovOQVuePDcfqHLT3mUZJA==
+
+esbuild-darwin-arm64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.47.tgz#cd40fd49a672fca581ed202834239dfe540a9028"
+  integrity sha512-seCmearlQyvdvM/noz1L9+qblC5vcBrhUaOoLEDDoLInF/VQ9IkobGiLlyTPYP5dW1YD4LXhtBgOyevoIHGGnw==
+
+esbuild-freebsd-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.47.tgz#8da6a14c095b29c01fc8087a16cb7906debc2d67"
+  integrity sha512-ZH8K2Q8/Ux5kXXvQMDsJcxvkIwut69KVrYQhza/ptkW50DC089bCVrJZZ3sKzIoOx+YPTrmsZvqeZERjyYrlvQ==
+
+esbuild-freebsd-arm64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.47.tgz#ad31f9c92817ff8f33fd253af7ab5122dc1b83f6"
+  integrity sha512-ZJMQAJQsIOhn3XTm7MPQfCzEu5b9STNC+s90zMWe2afy9EwnHV7Ov7ohEMv2lyWlc2pjqLW8QJnz2r0KZmeAEQ==
+
+esbuild-linux-32@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.47.tgz#de085e4db2e692ea30c71208ccc23fdcf5196c58"
+  integrity sha512-FxZOCKoEDPRYvq300lsWCTv1kcHgiiZfNrPtEhFAiqD7QZaXrad8LxyJ8fXGcWzIFzRiYZVtB3ttvITBvAFhKw==
+
+esbuild-linux-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.47.tgz#2a9321bbccb01f01b04cebfcfccbabeba3658ba1"
+  integrity sha512-nFNOk9vWVfvWYF9YNYksZptgQAdstnDCMtR6m42l5Wfugbzu11VpMCY9XrD4yFxvPo9zmzcoUL/88y0lfJZJJw==
+
+esbuild-linux-arm64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.47.tgz#b9da7b6fc4b0ca7a13363a0c5b7bb927e4bc535a"
+  integrity sha512-ywfme6HVrhWcevzmsufjd4iT3PxTfCX9HOdxA7Hd+/ZM23Y9nXeb+vG6AyA6jgq/JovkcqRHcL9XwRNpWG6XRw==
+
+esbuild-linux-arm@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.47.tgz#56fec2a09b9561c337059d4af53625142aded853"
+  integrity sha512-ZGE1Bqg/gPRXrBpgpvH81tQHpiaGxa8c9Rx/XOylkIl2ypLuOcawXEAo8ls+5DFCcRGt/o3sV+PzpAFZobOsmA==
+
+esbuild-linux-mips64le@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.47.tgz#9db21561f8f22ed79ef2aedb7bbef082b46cf823"
+  integrity sha512-mg3D8YndZ1LvUiEdDYR3OsmeyAew4MA/dvaEJxvyygahWmpv1SlEEnhEZlhPokjsUMfRagzsEF/d/2XF+kTQGg==
+
+esbuild-linux-ppc64le@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.47.tgz#dc3a3da321222b11e96e50efafec9d2de408198b"
+  integrity sha512-WER+f3+szmnZiWoK6AsrTKGoJoErG2LlauSmk73LEZFQ/iWC+KhhDsOkn1xBUpzXWsxN9THmQFltLoaFEH8F8w==
+
+esbuild-linux-riscv64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.47.tgz#9bd6dcd3dca6c0357084ecd06e1d2d4bf105335f"
+  integrity sha512-1fI6bP3A3rvI9BsaaXbMoaOjLE3lVkJtLxsgLHqlBhLlBVY7UqffWBvkrX/9zfPhhVMd9ZRFiaqXnB1T7BsL2g==
+
+esbuild-linux-s390x@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.47.tgz#a458af939b52f2cd32fc561410d441a51f69d41f"
+  integrity sha512-eZrWzy0xFAhki1CWRGnhsHVz7IlSKX6yT2tj2Eg8lhAwlRE5E96Hsb0M1mPSE1dHGpt1QVwwVivXIAacF/G6mw==
+
+esbuild-netbsd-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.47.tgz#6388e785d7e7e4420cb01348d7483ab511b16aa8"
+  integrity sha512-Qjdjr+KQQVH5Q2Q1r6HBYswFTToPpss3gqCiSw2Fpq/ua8+eXSQyAMG+UvULPqXceOwpnPo4smyZyHdlkcPppQ==
+
+esbuild-openbsd-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.47.tgz#309af806db561aa886c445344d1aacab850dbdc5"
+  integrity sha512-QpgN8ofL7B9z8g5zZqJE+eFvD1LehRlxr25PBkjyyasakm4599iroUpaj96rdqRlO2ShuyqwJdr+oNqWwTUmQw==
+
+esbuild-register@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/esbuild-register/-/esbuild-register-3.3.3.tgz#5bd80025c80caf77e6484ced5cc77233b1d39688"
+  integrity sha512-eFHOkutgIMJY5gc8LUp/7c+LLlDqzNi9T6AwCZ2WKKl3HmT+5ef3ZRyPPxDOynInML0fgaC50yszPKfPnjC0NQ==
+
+esbuild-sunos-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.47.tgz#3f19612dcdb89ba6c65283a7ff6e16f8afbf8aaa"
+  integrity sha512-uOeSgLUwukLioAJOiGYm3kNl+1wJjgJA8R671GYgcPgCx7QR73zfvYqXFFcIO93/nBdIbt5hd8RItqbbf3HtAQ==
+
+esbuild-windows-32@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.47.tgz#a92d279c8458d5dc319abcfeb30aa49e8f2e6f7f"
+  integrity sha512-H0fWsLTp2WBfKLBgwYT4OTfFly4Im/8B5f3ojDv1Kx//kiubVY0IQunP2Koc/fr/0wI7hj3IiBDbSrmKlrNgLQ==
+
+esbuild-windows-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.47.tgz#2564c3fcf0c23d701edb71af8c52d3be4cec5f8a"
+  integrity sha512-/Pk5jIEH34T68r8PweKRi77W49KwanZ8X6lr3vDAtOlH5EumPE4pBHqkCUdELanvsT14yMXLQ/C/8XPi1pAtkQ==
+
+esbuild-windows-arm64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.47.tgz#86d9db1a22d83360f726ac5fba41c2f625db6878"
+  integrity sha512-HFSW2lnp62fl86/qPQlqw6asIwCnEsEoNIL1h2uVMgakddf+vUuMcCbtUY1i8sst7KkgHrVKCJQB33YhhOweCQ==
+
+esbuild@^0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.47.tgz#0d6415f6bd8eb9e73a58f7f9ae04c5276cda0e4d"
+  integrity sha512-wI4ZiIfFxpkuxB8ju4MHrGwGLyp1+awEHAHVpx6w7a+1pmYIq8T9FGEVVwFo0iFierDoMj++Xq69GXWYn2EiwA==
+  optionalDependencies:
+    esbuild-android-64 "0.14.47"
+    esbuild-android-arm64 "0.14.47"
+    esbuild-darwin-64 "0.14.47"
+    esbuild-darwin-arm64 "0.14.47"
+    esbuild-freebsd-64 "0.14.47"
+    esbuild-freebsd-arm64 "0.14.47"
+    esbuild-linux-32 "0.14.47"
+    esbuild-linux-64 "0.14.47"
+    esbuild-linux-arm "0.14.47"
+    esbuild-linux-arm64 "0.14.47"
+    esbuild-linux-mips64le "0.14.47"
+    esbuild-linux-ppc64le "0.14.47"
+    esbuild-linux-riscv64 "0.14.47"
+    esbuild-linux-s390x "0.14.47"
+    esbuild-netbsd-64 "0.14.47"
+    esbuild-openbsd-64 "0.14.47"
+    esbuild-sunos-64 "0.14.47"
+    esbuild-windows-32 "0.14.47"
+    esbuild-windows-64 "0.14.47"
+    esbuild-windows-arm64 "0.14.47"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -8189,6 +8340,23 @@ pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+playwright-core@1.22.2:
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.22.2.tgz#ed2963d79d71c2a18d5a6fd25b60b9f0a344661a"
+  integrity sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q==
+
+playwright-core@1.23.1:
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.23.1.tgz#af02bd7568af1017e477433b1b003ba84e1eb312"
+  integrity sha512-9CXsE0gawph4KXl6oUaa0ehHRySZjHvly4TybcBXDvzK3N3o6L/eZ8Q6iVWUiMn0LLS5bRFxo1qEtOETlYJxjw==
+
+playwright@^1.22.2:
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.22.2.tgz#353a7c29f89ca9600edc7a9a30aed790823c797d"
+  integrity sha512-hUTpg7LytIl3/O4t0AQJS1V6hWsaSY5uZ7w1oCC8r3a1AQN5d6otIdCkiB3cbzgQkcMaRxisinjMFMVqZkybdQ==
+  dependencies:
+    playwright-core "1.22.2"
+
 plur@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/plur/-/plur-3.1.1.tgz#60267967866a8d811504fe58f2faaba237546a5b"
@@ -8227,6 +8395,11 @@ prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-hrtime@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
This PR:
- adds a new `playwright-extra` package
- it features a puppeteer compatibility layer so existing plugins derived from `PuppeteerExtraPlugin` (and expecting certain puppeteer methods) can be used with it
- currently tested and optimized for the stealth (chromium) and recaptcha (chromium, firefox, webkit) plugin

This approach is much more sane as opposed to switching everything to a new shared plugin base class at once, as attempted in #303 
Further background on the reasoning behind this strategy change can be found here: https://github.com/berstend/puppeteer-extra/issues/454#issuecomment-1169678855

The code (informed by maintaining a plugin framework for 4 years now 😄) is in parts much more elegant than puppeteer-extra and once some overdue housekeeping in the repo has been done I plan to refactor puppeteer-extra as well

The next steps are
- fixing any bugs that might come up related to the core framework functionality (augmenting playwright, plugin handling/events)
- improving the compatibility layer and supporting more puppeteer-extra plugins
- make very slight changes to the existing plugins to help improve playwright usage (e.g. the Page type mods in the recaptcha plugin)
- more documentation (new features, playwright caveats, how to contribute playwright plugins)

Eventually
- deciding on the best way to properly support both playwright & puppeteer (most likely with a new shared base plugin class)
- code reuse between playwright-extra & puppeteer-extra
