### PR TITLE
feat(plugin-recaptcha): Add playwright type mods

### DIFF
--- a/packages/puppeteer-extra-plugin-recaptcha/src/playwright-mods.d.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/playwright-mods.d.ts
@@ -1,0 +1,9 @@
+// Extend Playwright interfaces transparently to the end user.
+import {} from 'playwright-core'
+
+import { RecaptchaPluginPageAdditions } from './types'
+
+declare module 'playwright-core' {
+  interface Page extends RecaptchaPluginPageAdditions {}
+  interface Frame extends RecaptchaPluginPageAdditions {}
+}

--- a/packages/puppeteer-extra-plugin-recaptcha/src/types.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/types.ts
@@ -1,4 +1,5 @@
 /// <reference path="./puppeteer-mods.d.ts" />
+/// <reference path="./playwright-mods.d.ts" />
 // Warn: The above is EXTREMELY important for our custom page mods to be recognized by the end users typescript!
 
 /**


### PR DESCRIPTION
This allows e.g. `await page.solveRecaptchas()` to be used with type support when playwright-extra is driving the plugin (#664)