### PR TITLE
chore(puppeteer-extra): Remove deprecated `puppeteer-firefox`

### DIFF
--- a/packages/puppeteer-extra/package.json
+++ b/packages/puppeteer-extra/package.json
@@ -48,7 +48,6 @@
     "puppeteer": "^10.2.0",
     "puppeteer-extra-plugin": "^3.2.0",
     "puppeteer-extra-plugin-anonymize-ua": "^2.4.1",
-    "puppeteer-firefox": "^0.5.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.27.5",
     "rollup-plugin-commonjs": "^10.1.0",

--- a/packages/puppeteer-extra/readme.md
+++ b/packages/puppeteer-extra/readme.md
@@ -385,7 +385,7 @@ A few plugins won't work in headless mode (it's noted if that's the case) due to
 Big refactor, the core is now **written in TypeScript** 🎉
 That means out of the box type safety for fellow TS users and nice auto-completion in VSCode for JS users. Also:
 
-- A new [`addExtra`](#addextrapuppeteer) export, to **patch any puppeteer compatible library with plugin functionality** (`puppeteer-firefox`, `chrome-aws-lambda`, etc). This also allows for multiple puppeteer instances with different plugins.
+- A new [`addExtra`](#addextrapuppeteer) export, to **patch any puppeteer compatible library with plugin functionality** (`chrome-aws-lambda`, etc). This also allows for multiple puppeteer instances with different plugins.
 
 The API is backwards compatible, I bumped the major version just in case I missed something. Please report any issues you might find with the new release. :)
 
@@ -586,13 +586,15 @@ Example:
 
 ```javascript
 // js import
+const puppeteerVanilla = require('puppeteer')
 const { addExtra } = require('puppeteer-extra')
 
 // ts/es6 import
+import puppeteerVanilla from 'puppeteer'
 import { addExtra } from 'puppeteer-extra'
 
-// Patch e.g. puppeteer-firefox and add plugins
-const puppeteer = addExtra(require('puppeteer-firefox'))
+// Patch provided puppeteer and add plugins
+const puppeteer = addExtra(puppeteerVanilla)
 puppeteer.use(...)
 ```
 

--- a/packages/puppeteer-extra/src/index.ts
+++ b/packages/puppeteer-extra/src/index.ts
@@ -125,7 +125,6 @@ export class PuppeteerExtra implements VanillaPuppeteer {
 
     Alternatively:
     - To get puppeteer without the bundled Chromium browser install 'puppeteer-core'
-    - To use puppeteer-firefox install 'puppeteer-firefox' and use the 'addExtra' export
     `)
     throw this._requireError || new Error('No puppeteer instance provided.')
   }

--- a/packages/puppeteer-extra/test/addExtra.ts
+++ b/packages/puppeteer-extra/test/addExtra.ts
@@ -22,17 +22,3 @@ test('will throw without puppeteer', async t => {
   const pptr = addExtra(null as any)
   t.throws(() => pptr.pptr, null, 'No puppeteer instance provided.')
 })
-
-test('can work with puppeteer-firefox', async t => {
-  const pptrFF = require('puppeteer-firefox')
-  const puppeteer = addExtra(pptrFF)
-  t.truthy(Array.isArray(puppeteer.plugins))
-  const browser = await puppeteer.launch({ headless: true })
-  t.truthy(await browser.version())
-  const page = await browser.newPage()
-  await page.goto('https://example.com')
-  const title = await page.title()
-  t.true(title && title.toLowerCase().includes('example domain'))
-  await browser.close()
-  t.true(true)
-})


### PR DESCRIPTION
- Remove deprecated `puppeteer-firefox`
  - Fixes: #623, #512
