### PR TITLE
Captchas not being detected in sites with JS prototype polyfills

### DIFF
--- a/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/content.ts
@@ -259,7 +259,7 @@ export class RecaptchaContentScript {
     ]
     this.log('getIframesIds', results)
     // Deduplicate results by using the unique id as key
-    const dedup = Array.from(new Set(results))
+    const dedup = [...new Set(results)]
     this.log('getIframesIds - dedup', dedup)
     return dedup
   }


### PR DESCRIPTION
First of all, thank you the author of `puppeteer-extra` and its maintainers for the solid work on this :slightly_smiling_face:

Context: I wasn't able to make this library work at first in the website i'm scraping (unfortunely, don't have disclosure to share it). By looking at the Recaptcha plugin source code, I noticed the way we look for the captcha iframes (and do other stuff too) is by injecting a script in the browser context and running it.

I thought my problem had to do with the library not being able to locate the captcha iframe, but after debugging, turns out it was being located, but when deduping results with `Array.from(new Set(results))`, they were turning into an empty array.

Further investigating, i found that the site I was scraping was using a (low-quality) polyfill for `Array.from`, and as our script runs within that context, it was breaking with Sets.

This pull request contains the patch i used to work around this (spreading the Set instead of using `Array.from`). Not sure if this breaks other cases, but as both Sets and spread syntax are ES6, I don't think we are losing support.

<details>
  <summary>Screenshot from the tab with the aforementioned site:</summary>

 ![2022-07-29_09-05](https://user-images.githubusercontent.com/77419998/181759538-4009a308-9bb3-4f2b-8e2d-76fd52fc9ff9.png)

</details>

<details>
  <summary>Screenshot from a clean Chromium tab:</summary>

![2022-07-29_09-11](https://user-images.githubusercontent.com/77419998/181759573-6e9fbaee-d926-4124-8e08-29986693b10a.png)

</details>

Chromium version: 105.0.5173.0 (Developer Build)