### PR TITLE
feat(plugin-recaptcha) Allow custom data to be sent

### DIFF
--- a/packages/puppeteer-extra-plugin-recaptcha/src/index.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/index.ts
@@ -195,7 +195,8 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
 
   async getRecaptchaSolutions(
     captchas: types.CaptchaInfo[],
-    provider?: types.SolutionProvider
+    provider?: types.SolutionProvider,
+    extraData: { [key: string]: any } = {},
   ) {
     this.debug('getRecaptchaSolutions', { captchaNum: captchas.length })
     provider = provider || this.opts.provider
@@ -222,7 +223,8 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
       this,
       captchas,
       provider.token,
-      provider.opts || {}
+      provider.opts || {},
+      extraData
     )
     response.error =
       response.error ||
@@ -276,7 +278,8 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
   }
 
   async solveRecaptchas(
-    page: Page | Frame
+    page: Page | Frame,
+    extraData: { [key: string]: any } = {},
   ): Promise<types.SolveRecaptchasResult> {
     this.debug('solveRecaptchas')
     const response: types.SolveRecaptchasResult = {
@@ -301,7 +304,7 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
         const {
           solutions,
           error: solutionsError
-        } = await this.getRecaptchaSolutions(response.captchas)
+        } = await this.getRecaptchaSolutions(response.captchas, undefined, extraData)
         response.solutions = solutions
 
         const {
@@ -331,7 +334,7 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
     prop.enterRecaptchaSolutions = async (solutions: types.CaptchaSolution[]) =>
       this.enterRecaptchaSolutions(prop, solutions)
     // Add convenience methods that wraps all others
-    prop.solveRecaptchas = async () => this.solveRecaptchas(prop)
+    prop.solveRecaptchas = async () => this.solveRecaptchas.bind(this, prop)
   }
 
   async onPageCreated(page: Page) {

--- a/packages/puppeteer-extra-plugin-recaptcha/src/index.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/index.ts
@@ -334,7 +334,7 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
     prop.enterRecaptchaSolutions = async (solutions: types.CaptchaSolution[]) =>
       this.enterRecaptchaSolutions(prop, solutions)
     // Add convenience methods that wraps all others
-    prop.solveRecaptchas = async () => this.solveRecaptchas.bind(this, prop)
+    prop.solveRecaptchas = this.solveRecaptchas.bind(this, prop)
   }
 
   async onPageCreated(page: Page) {

--- a/packages/puppeteer-extra-plugin-recaptcha/src/provider/2captcha.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/provider/2captcha.ts
@@ -54,11 +54,12 @@ async function decodeRecaptchaAsync(
 export async function getSolutions(
   captchas: types.CaptchaInfo[] = [],
   token: string = '',
-  opts: TwoCaptchaProviderOpts = {}
+  opts: TwoCaptchaProviderOpts = {},
+  extraData: { [key: string]: any } = {},
 ): Promise<types.GetSolutionsResult> {
   opts = { ...providerOptsDefaults, ...opts }
   const solutions = await Promise.all(
-    captchas.map(c => getSolution(c, token, opts))
+    captchas.map(c => getSolution(c, token, opts, extraData))
   )
   return { solutions, error: solutions.find(s => !!s.error) }
 }
@@ -66,7 +67,8 @@ export async function getSolutions(
 async function getSolution(
   captcha: types.CaptchaInfo,
   token: string,
-  opts: TwoCaptchaProviderOpts
+  opts: TwoCaptchaProviderOpts,
+  extraData: { [key: string]: any } = {},
 ): Promise<types.CaptchaSolution> {
   const solution: types.CaptchaSolution = {
     _vendor: captcha._vendor,
@@ -79,7 +81,6 @@ async function getSolution(
     solution.id = captcha.id
     solution.requestAt = new Date()
     debug('Requesting solution..', solution)
-    const extraData = {}
     if (captcha.s) {
       extraData['data-s'] = captcha.s // google site specific property
     }


### PR DESCRIPTION
An improvement to previous additions that adds the `extraData` option as a parameter. Note: I did not test this code since I dont currently have the typescript build env installed.

This change should be backwards compatible (optional argument) and is a dirty fix to allow developers to send anything to the provider (there are some 2captcha API options that I could otherwise not send).