### PR TITLE
Resolved executablePath issue from the example.

### DIFF
--- a/packages/puppeteer-extra/readme.md
+++ b/packages/puppeteer-extra/readme.md
@@ -22,6 +22,7 @@ yarn add puppeteer@2.0.0 puppeteer-extra
 // it augments the installed puppeteer with plugin functionality.
 // Any number of plugins can be added through `puppeteer.use()`
 const puppeteer = require('puppeteer-extra')
+const { executablePath } = require('puppeteer') // puppeteer-core now requires executablePath as mandatory
 
 // Add stealth plugin and use defaults (all tricks to hide puppeteer usage)
 const StealthPlugin = require('puppeteer-extra-plugin-stealth')
@@ -32,7 +33,7 @@ const AdblockerPlugin = require('puppeteer-extra-plugin-adblocker')
 puppeteer.use(AdblockerPlugin({ blockTrackers: true }))
 
 // That's it, the rest is puppeteer usage as normal 😊
-puppeteer.launch({ headless: true }).then(async browser => {
+puppeteer.launch({ headless: true, executablePath: executablePath() }).then(async browser => {
   const page = await browser.newPage()
   await page.setViewport({ width: 800, height: 600 })
 


### PR DESCRIPTION
In the latest version of puppeteer-core, it is mandatory to pass executablePath, or else it throws the below error 
```bash
Error: An `executablePath` or `channel` must be specified for `puppeteer-core`
```

This pull request will resolve this issue from the example code.