### PR TITLE
fix(puppeteer-extra): Prefer puppeteer over puppeteer-core

### DIFF
--- a/packages/puppeteer-extra/src/index.ts
+++ b/packages/puppeteer-extra/src/index.ts
@@ -527,12 +527,12 @@ export const addExtra = (puppeteer: VanillaPuppeteer): PuppeteerExtra =>
  */
 function requireVanillaPuppeteer(): [VanillaPuppeteer?, Error?] {
   try {
-    return [require('puppeteer-core'), undefined]
+    return [require('puppeteer'), undefined]
   } catch (_) {
     // noop
   }
   try {
-    return [require('puppeteer'), undefined]
+    return [require('puppeteer-core'), undefined]
   } catch (err) {
     return [undefined, err as Error]
   }


### PR DESCRIPTION
puppeteer started to depend on puppeteer-core since probably [v18.1.0](https://github.com/puppeteer/puppeteer/blob/bafdb4784ccfe4a35fec9e6d366e4d1b40a82e1b/packages/puppeteer/package.json), but there are some API limitations on puppeteer core, like `puppeeter.defaultDownloadPath()`