### PR TITLE
fix(plugin-recaptcha): Enhance esbuild transpilation support of content scripts

### DIFF
--- a/packages/puppeteer-extra-plugin-recaptcha/src/content-hcaptcha.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/content-hcaptcha.ts
@@ -22,6 +22,13 @@ export class HcaptchaContentScript {
     opts = ContentScriptDefaultOpts,
     data = ContentScriptDefaultData
   ) {
+    // Workaround for https://github.com/esbuild-kit/tsx/issues/113
+    if (typeof globalThis.__name === 'undefined') {
+      globalThis.__defProp = Object.defineProperty
+      globalThis.__name = (target, value) =>
+        globalThis.__defProp(target, 'name', { value, configurable: true })
+    }
+
     this.opts = opts
     this.data = data
   }

--- a/packages/puppeteer-extra-plugin-recaptcha/src/index.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/index.ts
@@ -72,6 +72,11 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
       scriptSource = HcaptchaContentScript.toString()
       scriptName = 'HcaptchaContentScript'
     }
+    // Some bundlers transform classes to anonymous classes that are assigned to
+    // vars (e.g. esbuild). In such cases, `unexpected token '{'` errors are thrown
+    // once the script is executed. Let's bring class name back to script in such
+    // cases!
+    scriptSource = scriptSource.replace(/class \{/, `class ${scriptName} {`)
     return `(async() => {
       const DATA = ${JSON.stringify(data || null)}
       const OPTS = ${JSON.stringify(this.contentScriptOpts)}


### PR DESCRIPTION
This PR builds on https://github.com/berstend/puppeteer-extra/pull/758

It also fixes a fix to workaround `esbuild`'s `__name` semantics: https://github.com/esbuild-kit/tsx/issues/113

The author of `esbuild` [recommends](https://github.com/evanw/esbuild/issues/1031) against calling `toString()` on a function or class as this library is doing and instead creating a separate build for these entrypoints. This results in a lot more deterministic functionality, but that would also involve a larger PR.

So for now, this is the minimal amount of code changes to get `puppeteer-extra-plugin-recaptcha`'s injected content scripts to work when used in an application that's compiled using `esbuild`.

I ran into this issue while building the [chatgpt node.js wrapper](https://github.com/transitive-bullshit/chatgpt-api), which uses uses `tsx` to transpile TS to JS on-the-fly (using `esbuild` under the hood).

Also just wanted to say hey @berstend 👋 I remember working with you a bit years ago back in the early days of this project. Really really impressive to see how far it's come 🔥

Thanks for all your hard work && cheers,
-- Travis