### PR TITLE
Make readme.md more consistent and fix small error

### DIFF
--- a/packages/playwright-extra/readme.md
+++ b/packages/playwright-extra/readme.md
@@ -30,10 +30,10 @@ const { chromium } = require('playwright-extra')
 
 // Load the stealth plugin and use defaults (all tricks to hide playwright usage)
 // Note: playwright-extra is compatible with most puppeteer-extra plugins
-const stealth = require('puppeteer-extra-plugin-stealth')()
+const StealthPlugin = require('puppeteer-extra-plugin-stealth')()
 
 // Add the plugin to playwright (any number of plugins can be added)
-chromium.use(stealth)
+chromium.use(StealthPlugin())
 
 // That's it, the rest is playwright usage as normal 😊
 chromium.launch({ headless: true }).then(async browser => {


### PR DESCRIPTION
Changed the naming of the imported puppeteer-extra-plugin-stealth from "stealth" to "StealthPlugin" to be more consistent with the rest of the ReadMe. Also actually called the function, otherwise there will obviously be an error.