### PR TITLE
Fix user agent hint platform for macOS

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
@@ -84,7 +84,7 @@ class Plugin extends PuppeteerExtraPlugin {
     // Get platform identifier (short or long version)
     const _getPlatform = (extended = false) => {
       if (ua.includes('Mac OS X')) {
-        return extended ? 'Mac OS X' : 'MacIntel'
+        return extended ? 'macOS' : 'MacIntel'
       } else if (ua.includes('Android')) {
         return 'Android'
       } else if (ua.includes('Linux')) {

--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.test.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.test.js
@@ -225,7 +225,7 @@ test('stealth: test if UA hints are correctly set - macOS 11', async t => {
     t.true(secondLoad.includes('sec-ch-ua-mobile: ?0'))
     t.true(secondLoad.includes('sec-ch-ua-full-version: "99.0.9999.99"'))
     t.true(secondLoad.includes('sec-ch-ua-arch: "x86"'))
-    t.true(secondLoad.includes('sec-ch-ua-platform: "Mac OS X"'))
+    t.true(secondLoad.includes('sec-ch-ua-platform: "macOS"'))
     t.true(secondLoad.includes('sec-ch-ua-platform-version: "11_1_0"'))
     t.true(secondLoad.includes('sec-ch-ua-model: ""'))
   }


### PR DESCRIPTION
This pull request fixes an issue with the `_getPlatform` function in the user-agent-override evasion where the user agent hint platform for macOS devices was incorrectly returned as 'Mac OS X' instead of 'macOS'. 
In the real world, the `sec-ch-ua-platform` header for macOS devices is set to 'macOS', as documented in the official MDN Web Docs (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-CH-UA-Platform).

The function has been updated to correctly return 'macOS' when the `extended` parameter is set to `true`. I have also updated the corresponding test case to reflect the change in the `sec-ch-ua-platform` header for macOS devices.