### PR TITLE
Not using ua if browser is firefox

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
@@ -64,9 +64,19 @@ class Plugin extends PuppeteerExtraPlugin {
 
   async onPageCreated(page) {
     // Determine the full user agent string, strip the "Headless" part
-    let ua =
+    let ua = this.opts.userAgent
+
+    const browser = await page.browser()
+
+    // "firefox" has no user agent (not sure what the exact name for chrome/ chromium is)
+    if (browser._name.includes("chrom")) {
       this.opts.userAgent ||
       (await page.browser().userAgent()).replace('HeadlessChrome/', 'Chrome/')
+    }
+
+    if (!ua) {
+      return
+    }
 
     if (
       this.opts.maskLinux &&


### PR DESCRIPTION
Puppeteer-Extra can also be used with Playwright (which allows firefox).

Firefox doesn't have a UA property (unlike chrome), so trying to run this method with FF prints a warning.