### PR TITLE
Fix user agent override silent failure

### DIFF
--- a/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
+++ b/packages/puppeteer-extra-plugin-stealth/evasions/user-agent-override/index.js
@@ -179,7 +179,7 @@ class Plugin extends PuppeteerExtraPlugin {
 
     const client =
       typeof page._client === 'function' ? page._client() : page._client
-    client.send('Network.setUserAgentOverride', override)
+    await client.send('Network.setUserAgentOverride', override)
   }
 
   async beforeLaunch(options) {


### PR DESCRIPTION
This PR provides a fix for the scenario when the puppeteer-extra-stealth-plugin fails on startup without raising the error. This scenario can be suppressed locally by defining the `process.on('unhandledRejection')` on the local environment, but on the lambda environment, this listener is not getting invoked since lambda prefers to exit directly on this type of error.

For this reason, the `send` invocation needs to be awaited for the error to be propagated properly.