### PR TITLE
Fix hcaptcha iframe URL parsing

### DIFF
--- a/packages/puppeteer-extra-plugin-recaptcha/src/content-hcaptcha.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/content-hcaptcha.ts
@@ -82,7 +82,7 @@ export class HcaptchaContentScript {
 
   private _extractInfoFromIframes(iframes: HTMLIFrameElement[]) {
     return iframes
-      .map(el => el.src.replace('.html#', '.html?'))
+      .map(el => el.src.replace('#', el.src.includes('?') ? '&' : '?'))
       .map(url => {
         const { searchParams } = new URL(url)
         const result: types.CaptchaInfo = {


### PR DESCRIPTION
### Background
The plugin currently fails to extract the id from the following hcaptcha iframe URL:
```
https://newassets.hcaptcha.com/captcha/v1/9766048/static/hcaptcha.html?_v=zannzkmur9r#frame=challenge&id=0adtku1fshu4&host=wcca.wicourts.gov&sentry=true&reportapi=https%3A%2F%2Faccounts.hcaptcha.com&recaptchacompat=true&custom=false&hl=en&tplinks=on&pstissuer=https%3A%2F%2Fpst-issuer.hcaptcha.com&sitekey=d99012c0-7c0c-4575-9f8f-962ee8cdca65&size=invisible&theme=light&origin=https%3A%2F%2Fwcca.wicourts.gov
```

https://jsfiddle.net/k3g08cbq/