### PR TITLE
Use opts.userDataDir if launchPersistentContext calls with empty args

### DIFF
--- a/packages/playwright-extra/src/extra.ts
+++ b/packages/playwright-extra/src/extra.ts
@@ -17,7 +17,7 @@ interface AugmentedLauncherAPIs
   extends Pick<
     PlaywrightBrowserLauncher,
     'launch' | 'launchPersistentContext' | 'connect' | 'connectOverCDP'
-  > {}
+  > { }
 
 /**
  * Modular plugin framework to teach `playwright` new tricks.
@@ -118,6 +118,14 @@ export class PlaywrightExtraClass implements AugmentedLauncherAPIs {
     // Give plugins the chance to modify the options before continuing
     options =
       (await this.plugins.dispatchBlocking('beforeLaunch', options)) || options
+
+    if ('userDataDir' in options && !userDataDir) {
+      userDataDir = (options as any).userDataDir
+      debug(
+        "A plugin defined userDataDir during .launchPersistentContext", userDataDir
+      )
+      delete (options as any).userDataDir
+    }
 
     const context = await this.launcher['launchPersistentContext'](
       userDataDir,


### PR DESCRIPTION
I'm trying to use  UserPreferencesPlugin, like
```
chromium.use(
      UserPreferencesPlugin({
        userPrefs: {
          download: {
            prompt_for_download: false,
            open_pdf_in_system_reader: true
          },
          plugins: {
            always_open_pdf_externally: true
          },
        },
      })
    );
chromium.use(StealthPlugin());
context = await chromium.launchPersistentContext("",  opts);
```
and according logs user-data-dir  never been picked up 
instead chrome has been running with `playwright_chromiumdev_profileXXX` temp dir
```
puppeteer-extra-plugin:user-data-dir Wrote file /var/folders/j8/fb74tww54y337579fd0rgqzr0000gn/T/puppeteer_dev_profile-K5tcyn/Default/Preferences +1ms
  pw:api => browserType.launchPersistentContext started +0ms
  pw:browser <launching> /Applications/Brave Browser.app/Contents/MacOS/Brave Browser --disable-field-trial-config ... --user-data-dir=/var/folders/j8/fb74tww54y337579fd0rgqzr0000gn/T/playwright_chromiumdev_profile-Br6TEW --remote-debugging-pipe about:blank +0ms
  pw:browser <launched> pid=73167 +71ms
```

after patch applied I'm getting this
```
puppeteer-extra-plugin:user-data-dir Wrote file /var/folders/j8/fb74tww54y337579fd0rgqzr0000gn/T/puppeteer_dev_profile-5bhXYb/Default/Preferences +1ms
...
  pw:api => browserType.launchPersistentContext started +0ms
  pw:browser <launching> /Applications/Brave Browser.app/Contents/MacOS/Brave Browser --disable-field-trial-config .... --user-data-dir=/var/folders/j8/fb74tww54y337579fd0rgqzr0000gn/T/puppeteer_dev_profile-5bhXYb --remote-debugging-pipe about:blank +0ms
 ```

which is right to me