### PR TITLE
Fix typo in puppeteer-extra docs change playright to playwright

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,7 +7,7 @@
 
 'package: core':
   - packages/automation-extra/**/*
-  - packages/playright-extra/**/*
+  - packages/playwright-extra/**/*
   - packages/puppeteer-extra/**/*
   - packages/automation-extra-plugin/**/*
   - packages/puppeteer-extra-plugin/**/*

--- a/packages/puppeteer-extra/readme.md
+++ b/packages/puppeteer-extra/readme.md
@@ -101,7 +101,7 @@ puppeteer
 <details>
  <summary><strong>Playwright usage</strong></summary><br/>
 
-[`playright-extra`](/packages/playwright-extra) with plugin support is available as well.
+[`playwright-extra`](/packages/playwright-extra) with plugin support is available as well.
 
 </details>
 


### PR DESCRIPTION
`playright` is probably meant to be `playwright`

I don't think `playright` is the actual name or intentional?

https://github.com/berstend/puppeteer-extra/blob/39248f1f5deeb21b1e7eb6ae07b8ef73f1231ab9/packages/puppeteer-extra/readme.md?plain=1#L104  
  
https://github.com/berstend/puppeteer-extra/blob/39248f1f5deeb21b1e7eb6ae07b8ef73f1231ab9/.github/labeler.yml#L10
  
Thank you! 😄 
