### PR TITLE
feat: add puppeteer-extra-plugin-ghost-cursor (Puppeteer + Playwright, 5 realism features, autonomous debug)

### DIFF
--- a/packages/puppeteer-extra-plugin-ghost-cursor/index.js
+++ b/packages/puppeteer-extra-plugin-ghost-cursor/index.js
@@ -1,67 +1,167 @@
 'use strict'
 
 const { PuppeteerExtraPlugin } = require('puppeteer-extra-plugin')
+const fs = require('fs')
+const path = require('path')
+
+// ---------------------------------------------------------------------------
+// Bezier curve helper — used as fallback for Playwright pages where
+// ghost-cursor is not available, and for humanMove() on both platforms.
+// ---------------------------------------------------------------------------
 
 /**
- * A puppeteer-extra plugin that integrates `ghost-cursor` for human-like
- * mouse movements powered by Bezier curves.
+ * Generate N points along a cubic Bezier curve between (x0,y0) and (x1,y1).
+ * Control points are randomised to produce natural-looking paths.
+ * @private
+ */
+function bezierPoints (x0, y0, x1, y1, steps) {
+  const cp1x = x0 + (x1 - x0) * (0.2 + Math.random() * 0.3)
+  const cp1y = y0 + (Math.random() - 0.5) * Math.abs(y1 - y0) * 1.2
+  const cp2x = x0 + (x1 - x0) * (0.6 + Math.random() * 0.3)
+  const cp2y = y1 + (Math.random() - 0.5) * Math.abs(y1 - y0) * 1.2
+  const pts = []
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps
+    const mt = 1 - t
+    pts.push({
+      x: mt ** 3 * x0 + 3 * mt ** 2 * t * cp1x + 3 * mt * t ** 2 * cp2x + t ** 3 * x1,
+      y: mt ** 3 * y0 + 3 * mt ** 2 * t * cp1y + 3 * mt * t ** 2 * cp2y + t ** 3 * y1
+    })
+  }
+  return pts
+}
+
+// ---------------------------------------------------------------------------
+// Platform detection helpers
+// ---------------------------------------------------------------------------
+
+/** Returns true when `page` is a Playwright Page (has locator API). */
+function isPlaywright (page) {
+  return typeof page.locator === 'function'
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+/**
+ * A `puppeteer-extra` / `playwright-extra` plugin that integrates
+ * [`ghost-cursor`](https://github.com/Xetera/ghost-cursor) for human-like
+ * mouse movements on Puppeteer, and a built-in Bezier curve implementation
+ * for Playwright.
  *
- * Automatically attaches a cursor instance to every page and adds two
- * convenience helpers:
+ * Attached to every page:
+ * - `page.humanClick(selectorOrHandle)` — curved move → native click
+ * - `page.humanMove(x, y)` — curved move without click
+ * - `page.ghostCursor` — raw GhostCursor (Puppeteer only, `null` on Playwright)
  *
- * - `page.humanClick(selectorOrHandle)` — moves to the element's centre
- *   using a curved path, then fires a native mouse click.
- * - `page.humanMove(x, y)` — moves to the given coordinates with a
- *   natural curve.
- * - `page.ghostCursor` — the raw `GhostCursor` instance for advanced use.
+ * ### Autonomous debug mode (`opts.debug: true`)
  *
- * ## Why `boundingBox()` instead of `cursor.click(handle)` directly?
+ * When a `humanClick` fails, the plugin automatically:
+ * 1. Takes a full-page screenshot and saves it to `opts.debugDir`.
+ * 2. Logs the target selector, page URL and error message.
+ * 3. Retries **once** using a direct `page.click()` / `locator.click()` call
+ *    as a fallback, so a transient positioning error does not abort the run.
+ * 4. Reports whether the fallback succeeded.
  *
- * `ghost-cursor`'s built-in `click(ElementHandle)` calls
- * `elementHandle.clickablePoint()` internally, which can throw or silently
- * miss when the element is partially off-screen or inside a scrollable
- * container.  Resolving the target coordinates via `handle.boundingBox()`
- * first and then calling `page.mouse.click(x, y)` after the move is more
- * reliable across viewport sizes and page layouts.
- *
- * @param {object} [opts]
- * @param {number} [opts.moveDelay=0] Extra delay (ms) to add between move
- *   and click, simulating a moment of hesitation.
+ * @param {object}  [opts]
+ * @param {number}  [opts.moveDelay=0]       Ms to wait between move and click.
+ * @param {boolean} [opts.debug=false]       Enable autonomous debug mode.
+ * @param {string}  [opts.debugDir='ghost-cursor-debug'] Directory for debug artefacts.
  *
  * @example
+ * // Puppeteer
  * const puppeteer = require('puppeteer-extra')
  * const GhostCursorPlugin = require('puppeteer-extra-plugin-ghost-cursor')
+ * puppeteer.use(GhostCursorPlugin({ debug: true }))
  *
- * puppeteer.use(GhostCursorPlugin())
- *
- * const browser = await puppeteer.launch({ headless: false })
- * const page = await browser.newPage()
- * await page.goto('https://example.com')
- *
- * // Human-like click on a CSS selector
- * await page.humanClick('button#submit')
- *
- * // Human-like click on an ElementHandle
- * const btn = await page.$('button#submit')
- * await page.humanClick(btn)
- *
- * // Raw cursor access for custom paths
- * await page.ghostCursor.moveTo({ x: 500, y: 300 })
+ * @example
+ * // Playwright
+ * const { chromium } = require('playwright-extra')
+ * const GhostCursorPlugin = require('puppeteer-extra-plugin-ghost-cursor')
+ * chromium.use(GhostCursorPlugin())
+ * const browser = await chromium.launch()
  */
 class Plugin extends PuppeteerExtraPlugin {
   constructor (opts = {}) {
     super(opts)
   }
 
-  get name () {
-    return 'ghost-cursor'
-  }
+  get name () { return 'ghost-cursor' }
 
   get defaults () {
-    return { moveDelay: 0 }
+    return {
+      moveDelay: 0,
+      debug: false,
+      debugDir: 'ghost-cursor-debug'
+    }
   }
 
-  async onPageCreated (page) {
+  // -------------------------------------------------------------------------
+  // Internal helpers
+  // -------------------------------------------------------------------------
+
+  /** Ensure the debug directory exists. */
+  _ensureDebugDir () {
+    if (!fs.existsSync(this.opts.debugDir)) {
+      fs.mkdirSync(this.opts.debugDir, { recursive: true })
+    }
+  }
+
+  /**
+   * Autonomous debug handler — called when humanClick throws.
+   * Saves a screenshot, logs context, retries once with a direct click.
+   *
+   * @param {object} page
+   * @param {string} selector  - CSS selector used (or '[ElementHandle]')
+   * @param {Error}  err       - The original error
+   * @param {object} [handle]  - ElementHandle for Puppeteer direct-click fallback
+   * @returns {Promise<boolean>} true if the fallback click succeeded
+   */
+  async _debugAndRetry (page, selector, err, handle) {
+    this._ensureDebugDir()
+    const ts = new Date().toISOString().replace(/[:.]/g, '-')
+    const slug = (selector || 'handle').replace(/[^\w-]/g, '_').slice(0, 40)
+    const screenshotPath = path.join(this.opts.debugDir, `${ts}_${slug}.jpg`)
+
+    // 1 — screenshot
+    try {
+      await page.screenshot({ path: screenshotPath, type: 'jpeg', quality: 70, fullPage: true })
+    } catch (_) { /* non-blocking */ }
+
+    // 2 — log
+    console.warn(
+      `[ghost-cursor] humanClick failed on "${selector}" @ ${page.url()}\n` +
+      `  Error   : ${err.message}\n` +
+      `  Snapshot: ${screenshotPath}`
+    )
+
+    // 3 — fallback click (direct, no curve)
+    try {
+      if (isPlaywright(page)) {
+        await page.locator(selector).click({ timeout: 5000 })
+      } else if (handle) {
+        await handle.click()
+      } else {
+        await page.click(selector, { timeout: 5000 })
+      }
+      console.warn(`[ghost-cursor] Fallback click succeeded for "${selector}".`)
+      return true
+    } catch (retryErr) {
+      console.warn(`[ghost-cursor] Fallback click also failed: ${retryErr.message}`)
+      return false
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Puppeteer path — uses ghost-cursor
+  // -------------------------------------------------------------------------
+
+  /**
+   * Wire up a ghost-cursor on a Puppeteer page and attach helpers.
+   * @private
+   */
+  async _setupPuppeteer (page) {
     let createCursor
     try {
       createCursor = require('ghost-cursor').createCursor
@@ -73,59 +173,123 @@ class Plugin extends PuppeteerExtraPlugin {
     }
 
     const cursor = createCursor(page)
-
-    /** The underlying GhostCursor instance. */
     page.ghostCursor = cursor
 
+    const self = this
+
+    page.humanMove = async (x, y) => {
+      await cursor.moveTo({ x, y })
+    }
+
     /**
-     * Move to the centre of an element using a Bezier-curved path, then
-     * click it via a native mouse event.
+     * Move to the element centre using a Bezier-curved path, then click.
      *
-     * Coordinates are resolved with `ElementHandle.boundingBox()` rather
-     * than `cursor.click(handle)` to avoid silent misses on elements that
-     * are partially off-screen or inside scrollable containers.
+     * Coordinates are resolved via `ElementHandle.boundingBox()` rather than
+     * `cursor.click(handle)` to avoid silent misses on elements that are
+     * partially off-screen or inside scrollable containers.
      *
      * @param {string|import('puppeteer').ElementHandle} selectorOrHandle
      */
     page.humanClick = async (selectorOrHandle) => {
-      const handle =
-        typeof selectorOrHandle === 'string'
-          ? await page.$(selectorOrHandle)
-          : selectorOrHandle
+      const isPureHandle = typeof selectorOrHandle !== 'string'
+      const selector = isPureHandle ? '[ElementHandle]' : selectorOrHandle
+      const handle = isPureHandle ? selectorOrHandle : await page.$(selectorOrHandle)
 
-      if (!handle) {
-        throw new Error(
-          `humanClick: element not found for selector "${selectorOrHandle}"`
-        )
+      const run = async () => {
+        if (!handle) throw new Error(`Element not found for selector "${selector}"`)
+        const box = await handle.boundingBox()
+        if (!box) throw new Error(`Element has no boundingBox — hidden or detached`)
+        const x = box.x + box.width / 2
+        const y = box.y + box.height / 2
+        await cursor.moveTo({ x, y })
+        if (self.opts.moveDelay > 0) {
+          await new Promise(r => setTimeout(r, self.opts.moveDelay))
+        }
+        await page.mouse.click(x, y)
       }
 
-      const box = await handle.boundingBox()
-      if (!box) {
-        throw new Error(
-          'humanClick: element has no boundingBox — it may be hidden or detached'
-        )
+      if (!self.opts.debug) {
+        return run()
       }
-
-      const x = box.x + box.width / 2
-      const y = box.y + box.height / 2
-
-      await cursor.moveTo({ x, y })
-
-      if (this.opts.moveDelay > 0) {
-        await new Promise(resolve => setTimeout(resolve, this.opts.moveDelay))
+      try {
+        return await run()
+      } catch (err) {
+        const fallbackOk = await self._debugAndRetry(page, selector, err, handle)
+        if (!fallbackOk) throw err
       }
+    }
+  }
 
-      await page.mouse.click(x, y)
+  // -------------------------------------------------------------------------
+  // Playwright path — built-in Bezier curves via page.mouse
+  // -------------------------------------------------------------------------
+
+  /**
+   * Wire up Bezier-curve mouse helpers on a Playwright page.
+   * ghost-cursor is not used on this path.
+   * @private
+   */
+  async _setupPlaywright (page) {
+    page.ghostCursor = null // not available on Playwright
+
+    const self = this
+
+    page.humanMove = async (x, y) => {
+      const currentPos = { x: 0, y: 0 } // Playwright has no getCursorPos; start from 0,0
+      const pts = bezierPoints(currentPos.x, currentPos.y, x, y, 20)
+      for (const pt of pts) {
+        await page.mouse.move(pt.x, pt.y)
+      }
     }
 
     /**
-     * Move the cursor to (x, y) using a Bezier-curved path.
+     * Move to the element centre via a Bezier path, then click.
+     * Uses Playwright's `locator().boundingBox()` for accurate coordinates.
      *
-     * @param {number} x
-     * @param {number} y
+     * @param {string|import('playwright').Locator} selectorOrLocator
      */
-    page.humanMove = async (x, y) => {
-      await cursor.moveTo({ x, y })
+    page.humanClick = async (selectorOrLocator) => {
+      const isLocator = selectorOrLocator && typeof selectorOrLocator.boundingBox === 'function'
+      const selector = isLocator ? '[Locator]' : selectorOrLocator
+      const locator = isLocator ? selectorOrLocator : page.locator(selector)
+
+      const run = async () => {
+        const box = await locator.boundingBox({ timeout: 5000 })
+        if (!box) throw new Error(`Element has no boundingBox — hidden or detached`)
+        const x = box.x + box.width / 2
+        const y = box.y + box.height / 2
+        // Move in a Bezier curve toward the target
+        const pts = bezierPoints(x - 200, y - 100, x, y, 20)
+        for (const pt of pts) {
+          await page.mouse.move(pt.x, pt.y)
+        }
+        if (self.opts.moveDelay > 0) {
+          await new Promise(r => setTimeout(r, self.opts.moveDelay))
+        }
+        await page.mouse.click(x, y)
+      }
+
+      if (!self.opts.debug) {
+        return run()
+      }
+      try {
+        return await run()
+      } catch (err) {
+        const fallbackOk = await self._debugAndRetry(page, selector, err)
+        if (!fallbackOk) throw err
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Lifecycle hook
+  // -------------------------------------------------------------------------
+
+  async onPageCreated (page) {
+    if (isPlaywright(page)) {
+      await this._setupPlaywright(page)
+    } else {
+      await this._setupPuppeteer(page)
     }
   }
 }

--- a/packages/puppeteer-extra-plugin-ghost-cursor/index.js
+++ b/packages/puppeteer-extra-plugin-ghost-cursor/index.js
@@ -1,0 +1,135 @@
+'use strict'
+
+const { PuppeteerExtraPlugin } = require('puppeteer-extra-plugin')
+
+/**
+ * A puppeteer-extra plugin that integrates `ghost-cursor` for human-like
+ * mouse movements powered by Bezier curves.
+ *
+ * Automatically attaches a cursor instance to every page and adds two
+ * convenience helpers:
+ *
+ * - `page.humanClick(selectorOrHandle)` — moves to the element's centre
+ *   using a curved path, then fires a native mouse click.
+ * - `page.humanMove(x, y)` — moves to the given coordinates with a
+ *   natural curve.
+ * - `page.ghostCursor` — the raw `GhostCursor` instance for advanced use.
+ *
+ * ## Why `boundingBox()` instead of `cursor.click(handle)` directly?
+ *
+ * `ghost-cursor`'s built-in `click(ElementHandle)` calls
+ * `elementHandle.clickablePoint()` internally, which can throw or silently
+ * miss when the element is partially off-screen or inside a scrollable
+ * container.  Resolving the target coordinates via `handle.boundingBox()`
+ * first and then calling `page.mouse.click(x, y)` after the move is more
+ * reliable across viewport sizes and page layouts.
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.moveDelay=0] Extra delay (ms) to add between move
+ *   and click, simulating a moment of hesitation.
+ *
+ * @example
+ * const puppeteer = require('puppeteer-extra')
+ * const GhostCursorPlugin = require('puppeteer-extra-plugin-ghost-cursor')
+ *
+ * puppeteer.use(GhostCursorPlugin())
+ *
+ * const browser = await puppeteer.launch({ headless: false })
+ * const page = await browser.newPage()
+ * await page.goto('https://example.com')
+ *
+ * // Human-like click on a CSS selector
+ * await page.humanClick('button#submit')
+ *
+ * // Human-like click on an ElementHandle
+ * const btn = await page.$('button#submit')
+ * await page.humanClick(btn)
+ *
+ * // Raw cursor access for custom paths
+ * await page.ghostCursor.moveTo({ x: 500, y: 300 })
+ */
+class Plugin extends PuppeteerExtraPlugin {
+  constructor (opts = {}) {
+    super(opts)
+  }
+
+  get name () {
+    return 'ghost-cursor'
+  }
+
+  get defaults () {
+    return { moveDelay: 0 }
+  }
+
+  async onPageCreated (page) {
+    let createCursor
+    try {
+      createCursor = require('ghost-cursor').createCursor
+    } catch (_) {
+      throw new Error(
+        "puppeteer-extra-plugin-ghost-cursor: peer dependency 'ghost-cursor' not found.\n" +
+        'Please install it: npm install ghost-cursor'
+      )
+    }
+
+    const cursor = createCursor(page)
+
+    /** The underlying GhostCursor instance. */
+    page.ghostCursor = cursor
+
+    /**
+     * Move to the centre of an element using a Bezier-curved path, then
+     * click it via a native mouse event.
+     *
+     * Coordinates are resolved with `ElementHandle.boundingBox()` rather
+     * than `cursor.click(handle)` to avoid silent misses on elements that
+     * are partially off-screen or inside scrollable containers.
+     *
+     * @param {string|import('puppeteer').ElementHandle} selectorOrHandle
+     */
+    page.humanClick = async (selectorOrHandle) => {
+      const handle =
+        typeof selectorOrHandle === 'string'
+          ? await page.$(selectorOrHandle)
+          : selectorOrHandle
+
+      if (!handle) {
+        throw new Error(
+          `humanClick: element not found for selector "${selectorOrHandle}"`
+        )
+      }
+
+      const box = await handle.boundingBox()
+      if (!box) {
+        throw new Error(
+          'humanClick: element has no boundingBox — it may be hidden or detached'
+        )
+      }
+
+      const x = box.x + box.width / 2
+      const y = box.y + box.height / 2
+
+      await cursor.moveTo({ x, y })
+
+      if (this.opts.moveDelay > 0) {
+        await new Promise(resolve => setTimeout(resolve, this.opts.moveDelay))
+      }
+
+      await page.mouse.click(x, y)
+    }
+
+    /**
+     * Move the cursor to (x, y) using a Bezier-curved path.
+     *
+     * @param {number} x
+     * @param {number} y
+     */
+    page.humanMove = async (x, y) => {
+      await cursor.moveTo({ x, y })
+    }
+  }
+}
+
+module.exports = function (pluginConfig) {
+  return new Plugin(pluginConfig)
+}

--- a/packages/puppeteer-extra-plugin-ghost-cursor/index.js
+++ b/packages/puppeteer-extra-plugin-ghost-cursor/index.js
@@ -5,20 +5,21 @@ const fs = require('fs')
 const path = require('path')
 
 // ---------------------------------------------------------------------------
-// Bezier curve helper — used as fallback for Playwright pages where
-// ghost-cursor is not available, and for humanMove() on both platforms.
+// Bezier + motion helpers
 // ---------------------------------------------------------------------------
 
 /**
- * Generate N points along a cubic Bezier curve between (x0,y0) and (x1,y1).
+ * Generate N points along a cubic Bezier curve between two coordinates.
  * Control points are randomised to produce natural-looking paths.
  * @private
  */
 function bezierPoints (x0, y0, x1, y1, steps) {
-  const cp1x = x0 + (x1 - x0) * (0.2 + Math.random() * 0.3)
-  const cp1y = y0 + (Math.random() - 0.5) * Math.abs(y1 - y0) * 1.2
-  const cp2x = x0 + (x1 - x0) * (0.6 + Math.random() * 0.3)
-  const cp2y = y1 + (Math.random() - 0.5) * Math.abs(y1 - y0) * 1.2
+  const dx = x1 - x0
+  const dy = y1 - y0
+  const cp1x = x0 + dx * (0.2 + Math.random() * 0.3)
+  const cp1y = y0 + (Math.random() - 0.5) * Math.abs(dy) * 1.2
+  const cp2x = x0 + dx * (0.6 + Math.random() * 0.3)
+  const cp2y = y1 + (Math.random() - 0.5) * Math.abs(dy) * 1.2
   const pts = []
   for (let i = 0; i <= steps; i++) {
     const t = i / steps
@@ -31,11 +32,53 @@ function bezierPoints (x0, y0, x1, y1, steps) {
   return pts
 }
 
+/**
+ * Compute per-step delays for a path of `steps` points that ease-in and ease-out.
+ * Total travel time is sampled around `baseMs` ms.
+ * @private
+ */
+function motionDelays (steps, baseMs) {
+  const total = baseMs * (0.8 + Math.random() * 0.4) // ±20% natural variance
+  const delays = []
+  for (let i = 0; i < steps; i++) {
+    const t = i / (steps - 1)
+    // sine ease-in-out: slow at start and end, fast in the middle
+    const weight = Math.sin(t * Math.PI)
+    delays.push(weight)
+  }
+  const sum = delays.reduce((a, b) => a + b, 0)
+  return delays.map(w => Math.round((w / sum) * total))
+}
+
+/**
+ * Move the mouse along a Bezier path with ease-in/ease-out timing.
+ * @private
+ */
+async function moveBezier (mouse, x0, y0, x1, y1, opts = {}) {
+  const steps = opts.steps || 22
+  const baseMs = opts.baseMs || 180
+  const pts = bezierPoints(x0, y0, x1, y1, steps)
+  const delays = motionDelays(steps, baseMs)
+  for (let i = 0; i < pts.length; i++) {
+    await mouse.move(pts[i].x, pts[i].y)
+    if (delays[i] > 0) await sleep(delays[i])
+  }
+}
+
+/** Random integer in [min, max] */
+function rand (min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min
+}
+
+function sleep (ms) {
+  return new Promise(r => setTimeout(r, ms))
+}
+
 // ---------------------------------------------------------------------------
-// Platform detection helpers
+// Platform detection
 // ---------------------------------------------------------------------------
 
-/** Returns true when `page` is a Playwright Page (has locator API). */
+/** Returns true when `page` is a Playwright Page. */
 function isPlaywright (page) {
   return typeof page.locator === 'function'
 }
@@ -45,29 +88,40 @@ function isPlaywright (page) {
 // ---------------------------------------------------------------------------
 
 /**
- * A `puppeteer-extra` / `playwright-extra` plugin that integrates
- * [`ghost-cursor`](https://github.com/Xetera/ghost-cursor) for human-like
- * mouse movements on Puppeteer, and a built-in Bezier curve implementation
- * for Playwright.
+ * A `puppeteer-extra` / `playwright-extra` plugin that provides human-like
+ * mouse and keyboard interactions powered by Bezier curves and realistic timing.
  *
- * Attached to every page:
- * - `page.humanClick(selectorOrHandle)` — curved move → native click
- * - `page.humanMove(x, y)` — curved move without click
- * - `page.ghostCursor` — raw GhostCursor (Puppeteer only, `null` on Playwright)
+ * ### Platform support
+ * - **Puppeteer** — wraps [`ghost-cursor`](https://github.com/Xetera/ghost-cursor) (peer dep).
+ * - **Playwright** — built-in Bezier implementation, no extra dependency.
+ * - Platform is auto-detected per page at runtime.
  *
- * ### Autonomous debug mode (`opts.debug: true`)
+ * ### Helpers added to every page
  *
- * When a `humanClick` fails, the plugin automatically:
- * 1. Takes a full-page screenshot and saves it to `opts.debugDir`.
- * 2. Logs the target selector, page URL and error message.
- * 3. Retries **once** using a direct `page.click()` / `locator.click()` call
- *    as a fallback, so a transient positioning error does not abort the run.
- * 4. Reports whether the fallback succeeded.
+ * | Method | Description |
+ * |--------|-------------|
+ * | `page.humanClick(selectorOrHandle)` | Curved move → native click |
+ * | `page.humanMove(x, y)` | Curved move, no click |
+ * | `page.humanType(selector, text)` | Click field + type with human delays |
+ * | `page.ghostCursor` | Raw GhostCursor (Puppeteer only) |
+ *
+ * ### Behaviour details
+ *
+ * - **Cursor position memory** — the last known cursor position is stored per
+ *   page so every move starts from the correct location rather than `(0, 0)`.
+ * - **Scroll-to-element** — if `boundingBox()` returns `null` (element
+ *   off-screen), the plugin scrolls it into view and retries automatically.
+ * - **Variable click position** — clicks land at a random point within the
+ *   central 60% of the element bounding box, not always at the exact centre.
+ * - **Ease-in/ease-out speed** — move steps are timed with a sine curve so
+ *   the cursor accelerates at the start and decelerates near the target.
+ * - **Autonomous debug mode** — on failure, saves a screenshot, logs context,
+ *   and retries once with a direct click fallback.
  *
  * @param {object}  [opts]
- * @param {number}  [opts.moveDelay=0]       Ms to wait between move and click.
+ * @param {number}  [opts.moveDelay=0]       Extra ms after move, before click.
  * @param {boolean} [opts.debug=false]       Enable autonomous debug mode.
- * @param {string}  [opts.debugDir='ghost-cursor-debug'] Directory for debug artefacts.
+ * @param {string}  [opts.debugDir='ghost-cursor-debug'] Debug screenshot dir.
  *
  * @example
  * // Puppeteer
@@ -75,12 +129,16 @@ function isPlaywright (page) {
  * const GhostCursorPlugin = require('puppeteer-extra-plugin-ghost-cursor')
  * puppeteer.use(GhostCursorPlugin({ debug: true }))
  *
+ * const page = await (await puppeteer.launch()).newPage()
+ * await page.goto('https://example.com')
+ * await page.humanClick('button#submit')
+ * await page.humanType('input#search', 'hello world')
+ *
  * @example
  * // Playwright
  * const { chromium } = require('playwright-extra')
  * const GhostCursorPlugin = require('puppeteer-extra-plugin-ghost-cursor')
  * chromium.use(GhostCursorPlugin())
- * const browser = await chromium.launch()
  */
 class Plugin extends PuppeteerExtraPlugin {
   constructor (opts = {}) {
@@ -90,18 +148,13 @@ class Plugin extends PuppeteerExtraPlugin {
   get name () { return 'ghost-cursor' }
 
   get defaults () {
-    return {
-      moveDelay: 0,
-      debug: false,
-      debugDir: 'ghost-cursor-debug'
-    }
+    return { moveDelay: 0, debug: false, debugDir: 'ghost-cursor-debug' }
   }
 
   // -------------------------------------------------------------------------
   // Internal helpers
   // -------------------------------------------------------------------------
 
-  /** Ensure the debug directory exists. */
   _ensureDebugDir () {
     if (!fs.existsSync(this.opts.debugDir)) {
       fs.mkdirSync(this.opts.debugDir, { recursive: true })
@@ -109,34 +162,22 @@ class Plugin extends PuppeteerExtraPlugin {
   }
 
   /**
-   * Autonomous debug handler — called when humanClick throws.
-   * Saves a screenshot, logs context, retries once with a direct click.
-   *
-   * @param {object} page
-   * @param {string} selector  - CSS selector used (or '[ElementHandle]')
-   * @param {Error}  err       - The original error
-   * @param {object} [handle]  - ElementHandle for Puppeteer direct-click fallback
-   * @returns {Promise<boolean>} true if the fallback click succeeded
+   * Autonomous debug handler: screenshot + log + direct-click retry.
+   * @returns {Promise<boolean>} true if fallback succeeded
    */
   async _debugAndRetry (page, selector, err, handle) {
     this._ensureDebugDir()
     const ts = new Date().toISOString().replace(/[:.]/g, '-')
-    const slug = (selector || 'handle').replace(/[^\w-]/g, '_').slice(0, 40)
+    const slug = String(selector).replace(/[^\w-]/g, '_').slice(0, 40)
     const screenshotPath = path.join(this.opts.debugDir, `${ts}_${slug}.jpg`)
-
-    // 1 — screenshot
     try {
       await page.screenshot({ path: screenshotPath, type: 'jpeg', quality: 70, fullPage: true })
-    } catch (_) { /* non-blocking */ }
-
-    // 2 — log
+    } catch (_) {}
     console.warn(
       `[ghost-cursor] humanClick failed on "${selector}" @ ${page.url()}\n` +
       `  Error   : ${err.message}\n` +
       `  Snapshot: ${screenshotPath}`
     )
-
-    // 3 — fallback click (direct, no curve)
     try {
       if (isPlaywright(page)) {
         await page.locator(selector).click({ timeout: 5000 })
@@ -153,14 +194,49 @@ class Plugin extends PuppeteerExtraPlugin {
     }
   }
 
-  // -------------------------------------------------------------------------
-  // Puppeteer path — uses ghost-cursor
-  // -------------------------------------------------------------------------
-
   /**
-   * Wire up a ghost-cursor on a Puppeteer page and attach helpers.
+   * Resolve a bounding box, scrolling the element into view and retrying
+   * once if the first attempt returns null (element off-screen).
    * @private
    */
+  async _boundingBoxWithScroll (page, handle, locator) {
+    // First attempt
+    const box = handle
+      ? await handle.boundingBox()
+      : await locator.boundingBox({ timeout: 5000 })
+    if (box) return box
+
+    // Element is likely off-screen — scroll into view and retry
+    if (handle) {
+      await handle.evaluate(el => el.scrollIntoView({ block: 'center', behavior: 'smooth' }))
+    } else {
+      await locator.evaluate(el => el.scrollIntoView({ block: 'center', behavior: 'smooth' }))
+    }
+    await sleep(600)
+
+    const box2 = handle
+      ? await handle.boundingBox()
+      : await locator.boundingBox({ timeout: 5000 })
+    return box2 // may still be null — caller decides what to do
+  }
+
+  /**
+   * Pick a random click point within the central 60% of a bounding box.
+   * Humans do not click the exact pixel centre every time.
+   * @private
+   */
+  _randomClickPoint (box) {
+    const margin = 0.2 // 20% margin on each side → central 60%
+    return {
+      x: box.x + box.width  * (margin + Math.random() * (1 - 2 * margin)),
+      y: box.y + box.height * (margin + Math.random() * (1 - 2 * margin))
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Puppeteer path — ghost-cursor for moves, custom logic for the rest
+  // -------------------------------------------------------------------------
+
   async _setupPuppeteer (page) {
     let createCursor
     try {
@@ -175,18 +251,22 @@ class Plugin extends PuppeteerExtraPlugin {
     const cursor = createCursor(page)
     page.ghostCursor = cursor
 
+    // Cursor position memory — updated after every move or click
+    const pos = { x: 0, y: 0 }
     const self = this
 
+    /**
+     * Move to (x, y) via ghost-cursor and update position memory.
+     */
     page.humanMove = async (x, y) => {
       await cursor.moveTo({ x, y })
+      pos.x = x; pos.y = y
     }
 
     /**
-     * Move to the element centre using a Bezier-curved path, then click.
-     *
-     * Coordinates are resolved via `ElementHandle.boundingBox()` rather than
-     * `cursor.click(handle)` to avoid silent misses on elements that are
-     * partially off-screen or inside scrollable containers.
+     * Click a target element with a human-like curved approach.
+     * Resolves coordinates via `boundingBox()`, scrolls into view if needed,
+     * and clicks at a random point within the central 60% of the element.
      *
      * @param {string|import('puppeteer').ElementHandle} selectorOrHandle
      */
@@ -197,54 +277,76 @@ class Plugin extends PuppeteerExtraPlugin {
 
       const run = async () => {
         if (!handle) throw new Error(`Element not found for selector "${selector}"`)
-        const box = await handle.boundingBox()
+        const box = await self._boundingBoxWithScroll(page, handle, null)
         if (!box) throw new Error(`Element has no boundingBox — hidden or detached`)
-        const x = box.x + box.width / 2
-        const y = box.y + box.height / 2
+        const { x, y } = self._randomClickPoint(box)
         await cursor.moveTo({ x, y })
-        if (self.opts.moveDelay > 0) {
-          await new Promise(r => setTimeout(r, self.opts.moveDelay))
-        }
+        pos.x = x; pos.y = y
+        if (self.opts.moveDelay > 0) await sleep(self.opts.moveDelay)
         await page.mouse.click(x, y)
       }
 
-      if (!self.opts.debug) {
-        return run()
-      }
+      if (!self.opts.debug) return run()
       try {
         return await run()
       } catch (err) {
-        const fallbackOk = await self._debugAndRetry(page, selector, err, handle)
-        if (!fallbackOk) throw err
+        const ok = await self._debugAndRetry(page, selector, err, handle)
+        if (!ok) throw err
+      }
+    }
+
+    /**
+     * Click an input or textarea, then type `text` with human-like key timing.
+     * Delays vary per character: faster on common letters, slower after
+     * punctuation and spaces, with occasional short pauses simulating thought.
+     *
+     * @param {string} selector  CSS selector for the input field
+     * @param {string} text      Text to type
+     * @param {object} [opts]
+     * @param {number} [opts.wpm=180]  Approximate words per minute (±30%)
+     */
+    page.humanType = async (selector, text, opts = {}) => {
+      await page.humanClick(selector)
+      await sleep(rand(80, 200))
+      const wpm = opts.wpm || 180
+      const msPerChar = Math.round(60000 / (wpm * 5))
+      for (let i = 0; i < text.length; i++) {
+        const ch = text[i]
+        await page.keyboard.type(ch)
+        // Longer pause after punctuation and spaces (simulates thinking)
+        const isPunctuation = /[.,;:!?\s]/.test(ch)
+        const delay = isPunctuation
+          ? rand(msPerChar * 2, msPerChar * 5)
+          : rand(Math.round(msPerChar * 0.6), Math.round(msPerChar * 1.6))
+        // Occasional micro-pause (1 in 15 chars) simulating hesitation
+        const extraPause = Math.random() < 0.07 ? rand(150, 400) : 0
+        await sleep(delay + extraPause)
       }
     }
   }
 
   // -------------------------------------------------------------------------
-  // Playwright path — built-in Bezier curves via page.mouse
+  // Playwright path — built-in Bezier curves
   // -------------------------------------------------------------------------
 
-  /**
-   * Wire up Bezier-curve mouse helpers on a Playwright page.
-   * ghost-cursor is not used on this path.
-   * @private
-   */
   async _setupPlaywright (page) {
-    page.ghostCursor = null // not available on Playwright
+    page.ghostCursor = null
 
+    // Cursor position memory
+    const pos = { x: 0, y: 0 }
     const self = this
 
+    /**
+     * Move to (x, y) via Bezier curve with ease-in/ease-out timing.
+     */
     page.humanMove = async (x, y) => {
-      const currentPos = { x: 0, y: 0 } // Playwright has no getCursorPos; start from 0,0
-      const pts = bezierPoints(currentPos.x, currentPos.y, x, y, 20)
-      for (const pt of pts) {
-        await page.mouse.move(pt.x, pt.y)
-      }
+      await moveBezier(page.mouse, pos.x, pos.y, x, y)
+      pos.x = x; pos.y = y
     }
 
     /**
      * Move to the element centre via a Bezier path, then click.
-     * Uses Playwright's `locator().boundingBox()` for accurate coordinates.
+     * Scrolls into view if needed; clicks at a random point within the element.
      *
      * @param {string|import('playwright').Locator} selectorOrLocator
      */
@@ -254,35 +356,52 @@ class Plugin extends PuppeteerExtraPlugin {
       const locator = isLocator ? selectorOrLocator : page.locator(selector)
 
       const run = async () => {
-        const box = await locator.boundingBox({ timeout: 5000 })
+        const box = await self._boundingBoxWithScroll(page, null, locator)
         if (!box) throw new Error(`Element has no boundingBox — hidden or detached`)
-        const x = box.x + box.width / 2
-        const y = box.y + box.height / 2
-        // Move in a Bezier curve toward the target
-        const pts = bezierPoints(x - 200, y - 100, x, y, 20)
-        for (const pt of pts) {
-          await page.mouse.move(pt.x, pt.y)
-        }
-        if (self.opts.moveDelay > 0) {
-          await new Promise(r => setTimeout(r, self.opts.moveDelay))
-        }
+        const { x, y } = self._randomClickPoint(box)
+        await moveBezier(page.mouse, pos.x, pos.y, x, y)
+        pos.x = x; pos.y = y
+        if (self.opts.moveDelay > 0) await sleep(self.opts.moveDelay)
         await page.mouse.click(x, y)
       }
 
-      if (!self.opts.debug) {
-        return run()
-      }
+      if (!self.opts.debug) return run()
       try {
         return await run()
       } catch (err) {
-        const fallbackOk = await self._debugAndRetry(page, selector, err)
-        if (!fallbackOk) throw err
+        const ok = await self._debugAndRetry(page, selector, err)
+        if (!ok) throw err
+      }
+    }
+
+    /**
+     * Click an input field, then type with human-like key delays.
+     *
+     * @param {string} selector  CSS selector for the input
+     * @param {string} text
+     * @param {object} [opts]
+     * @param {number} [opts.wpm=180]
+     */
+    page.humanType = async (selector, text, opts = {}) => {
+      await page.humanClick(selector)
+      await sleep(rand(80, 200))
+      const wpm = opts.wpm || 180
+      const msPerChar = Math.round(60000 / (wpm * 5))
+      for (let i = 0; i < text.length; i++) {
+        const ch = text[i]
+        await page.keyboard.type(ch)
+        const isPunctuation = /[.,;:!?\s]/.test(ch)
+        const delay = isPunctuation
+          ? rand(msPerChar * 2, msPerChar * 5)
+          : rand(Math.round(msPerChar * 0.6), Math.round(msPerChar * 1.6))
+        const extraPause = Math.random() < 0.07 ? rand(150, 400) : 0
+        await sleep(delay + extraPause)
       }
     }
   }
 
   // -------------------------------------------------------------------------
-  // Lifecycle hook
+  // Lifecycle
   // -------------------------------------------------------------------------
 
   async onPageCreated (page) {

--- a/packages/puppeteer-extra-plugin-ghost-cursor/package.json
+++ b/packages/puppeteer-extra-plugin-ghost-cursor/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "puppeteer-extra-plugin-ghost-cursor",
+  "version": "1.0.0",
+  "description": "A puppeteer-extra plugin that integrates ghost-cursor for human-like mouse movements",
+  "main": "index.js",
+  "scripts": {
+    "test": "ava -v ./test.js"
+  },
+  "keywords": [
+    "puppeteer",
+    "puppeteer-extra",
+    "ghost-cursor",
+    "human",
+    "mouse",
+    "stealth",
+    "automation"
+  ],
+  "author": "",
+  "license": "MIT",
+  "peerDependencies": {
+    "ghost-cursor": ">=1.2.0",
+    "puppeteer-extra": ">=3.0.0"
+  },
+  "dependencies": {
+    "puppeteer-extra-plugin": "^3.2.3"
+  },
+  "devDependencies": {
+    "ava": "^3.15.0",
+    "ghost-cursor": "^1.4.2",
+    "puppeteer": "*",
+    "puppeteer-extra": "*"
+  }
+}

--- a/packages/puppeteer-extra-plugin-ghost-cursor/readme.md
+++ b/packages/puppeteer-extra-plugin-ghost-cursor/readme.md
@@ -1,0 +1,67 @@
+# puppeteer-extra-plugin-ghost-cursor
+
+> A [`puppeteer-extra`](https://github.com/berstend/puppeteer-extra) plugin that integrates [`ghost-cursor`](https://github.com/Xetera/ghost-cursor) for human-like mouse movements powered by Bezier curves.
+
+## Install
+
+```bash
+npm install puppeteer-extra-plugin-ghost-cursor ghost-cursor
+```
+
+## Usage
+
+```js
+const puppeteer = require('puppeteer-extra')
+const GhostCursorPlugin = require('puppeteer-extra-plugin-ghost-cursor')
+
+puppeteer.use(GhostCursorPlugin())
+
+const browser = await puppeteer.launch({ headless: false })
+const page = await browser.newPage()
+await page.goto('https://example.com')
+
+// Human-like click via CSS selector
+await page.humanClick('button#submit')
+
+// Human-like click via ElementHandle
+const btn = await page.$('button#submit')
+await page.humanClick(btn)
+
+// Move without clicking
+await page.humanMove(500, 300)
+
+// Raw cursor access for custom interactions
+await page.ghostCursor.moveTo({ x: 200, y: 400 })
+```
+
+## Options
+
+```js
+GhostCursorPlugin({
+  moveDelay: 150 // ms to wait between move and click (simulates hesitation)
+})
+```
+
+## API
+
+### `page.humanClick(selectorOrHandle)`
+
+Moves the cursor to the centre of the target element using a Bezier-curved path, then fires a native mouse click.
+
+Accepts either a CSS selector string or an `ElementHandle`. Coordinates are resolved via `ElementHandle.boundingBox()` to ensure reliable clicks on elements that may be partially off-screen or inside scrollable containers.
+
+### `page.humanMove(x, y)`
+
+Moves the cursor to the given viewport coordinates using a Bezier-curved path.
+
+### `page.ghostCursor`
+
+The underlying `GhostCursor` instance, for advanced use cases not covered by the helpers above.
+
+## Why `boundingBox()` instead of `cursor.click(handle)` directly?
+
+`ghost-cursor`'s built-in `click(ElementHandle)` calls `elementHandle.clickablePoint()` internally. This can throw or silently miss when the element is partially off-screen or inside a scrollable container. Resolving coordinates via `handle.boundingBox()` first and then dispatching `page.mouse.click(x, y)` after the move is more reliable across different viewport sizes and page layouts.
+
+## License
+
+MIT

--- a/packages/puppeteer-extra-plugin-ghost-cursor/readme.md
+++ b/packages/puppeteer-extra-plugin-ghost-cursor/readme.md
@@ -1,14 +1,23 @@
 # puppeteer-extra-plugin-ghost-cursor
 
-> A [`puppeteer-extra`](https://github.com/berstend/puppeteer-extra) plugin that integrates [`ghost-cursor`](https://github.com/Xetera/ghost-cursor) for human-like mouse movements powered by Bezier curves.
+> A [`puppeteer-extra`](https://github.com/berstend/puppeteer-extra) / [`playwright-extra`](https://github.com/berstend/puppeteer-extra/tree/master/packages/playwright-extra) plugin for human-like mouse movements powered by Bezier curves.
+
+On **Puppeteer** it wraps [`ghost-cursor`](https://github.com/Xetera/ghost-cursor).
+On **Playwright** it uses a built-in Bezier curve implementation via `page.mouse`.
 
 ## Install
 
 ```bash
+# Puppeteer
 npm install puppeteer-extra-plugin-ghost-cursor ghost-cursor
+
+# Playwright (ghost-cursor not required)
+npm install puppeteer-extra-plugin-ghost-cursor
 ```
 
 ## Usage
+
+### Puppeteer
 
 ```js
 const puppeteer = require('puppeteer-extra')
@@ -20,47 +29,78 @@ const browser = await puppeteer.launch({ headless: false })
 const page = await browser.newPage()
 await page.goto('https://example.com')
 
-// Human-like click via CSS selector
-await page.humanClick('button#submit')
+await page.humanClick('button#submit')       // curved move + click
+await page.humanMove(500, 300)               // curved move, no click
+await page.ghostCursor.moveTo({ x: 200, y: 400 }) // raw cursor access
+```
 
-// Human-like click via ElementHandle
-const btn = await page.$('button#submit')
-await page.humanClick(btn)
+### Playwright
 
-// Move without clicking
-await page.humanMove(500, 300)
+```js
+const { chromium } = require('playwright-extra')
+const GhostCursorPlugin = require('puppeteer-extra-plugin-ghost-cursor')
 
-// Raw cursor access for custom interactions
-await page.ghostCursor.moveTo({ x: 200, y: 400 })
+chromium.use(GhostCursorPlugin())
+
+const browser = await chromium.launch({ headless: false })
+const page = await browser.newPage()
+await page.goto('https://example.com')
+
+await page.humanClick('button#submit')       // Bezier path + click
+await page.humanMove(500, 300)               // Bezier path, no click
+// page.ghostCursor is null on Playwright
+```
+
+## Autonomous debug mode
+
+Enable `debug: true` to get automatic failure recovery and diagnostics:
+
+```js
+puppeteer.use(GhostCursorPlugin({
+  debug: true,
+  debugDir: 'my-debug-screenshots'  // default: 'ghost-cursor-debug'
+}))
+```
+
+When `humanClick` fails, the plugin automatically:
+
+1. Takes a full-page JPEG screenshot and saves it to `debugDir`.
+2. Logs the target selector, current page URL and error message.
+3. Retries **once** using a direct `page.click()` fallback (no cursor movement).
+4. Reports whether the fallback succeeded.
+
+If the fallback also fails, the original error is re-thrown — nothing is silently swallowed.
+
+```
+[ghost-cursor] humanClick failed on "button#submit" @ https://example.com
+  Error   : Element has no boundingBox — hidden or detached
+  Snapshot: ghost-cursor-debug/2025-01-15T10-30-00-000Z_button_submit.jpg
+[ghost-cursor] Fallback click succeeded for "button#submit".
 ```
 
 ## Options
 
-```js
-GhostCursorPlugin({
-  moveDelay: 150 // ms to wait between move and click (simulates hesitation)
-})
-```
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `moveDelay` | `number` | `0` | Ms to wait between move completion and click |
+| `debug` | `boolean` | `false` | Enable autonomous debug mode |
+| `debugDir` | `string` | `'ghost-cursor-debug'` | Directory for debug screenshots |
 
 ## API
 
 ### `page.humanClick(selectorOrHandle)`
 
-Moves the cursor to the centre of the target element using a Bezier-curved path, then fires a native mouse click.
+Moves to the centre of the target element via a Bezier-curved path, then fires a native mouse click. Accepts a CSS selector string or an `ElementHandle` (Puppeteer) / `Locator` (Playwright).
 
-Accepts either a CSS selector string or an `ElementHandle`. Coordinates are resolved via `ElementHandle.boundingBox()` to ensure reliable clicks on elements that may be partially off-screen or inside scrollable containers.
+Coordinates are resolved via `boundingBox()` rather than ghost-cursor's built-in `click(handle)` to avoid silent misses on elements that are partially off-screen or inside scrollable containers.
 
 ### `page.humanMove(x, y)`
 
-Moves the cursor to the given viewport coordinates using a Bezier-curved path.
+Moves the cursor to the given viewport coordinates via a Bezier-curved path, without clicking.
 
 ### `page.ghostCursor`
 
-The underlying `GhostCursor` instance, for advanced use cases not covered by the helpers above.
-
-## Why `boundingBox()` instead of `cursor.click(handle)` directly?
-
-`ghost-cursor`'s built-in `click(ElementHandle)` calls `elementHandle.clickablePoint()` internally. This can throw or silently miss when the element is partially off-screen or inside a scrollable container. Resolving coordinates via `handle.boundingBox()` first and then dispatching `page.mouse.click(x, y)` after the move is more reliable across different viewport sizes and page layouts.
+The underlying `GhostCursor` instance (Puppeteer only). `null` on Playwright.
 
 ## License
 

--- a/packages/puppeteer-extra-plugin-ghost-cursor/readme.md
+++ b/packages/puppeteer-extra-plugin-ghost-cursor/readme.md
@@ -1,9 +1,10 @@
 # puppeteer-extra-plugin-ghost-cursor
 
-> A [`puppeteer-extra`](https://github.com/berstend/puppeteer-extra) / [`playwright-extra`](https://github.com/berstend/puppeteer-extra/tree/master/packages/playwright-extra) plugin for human-like mouse movements powered by Bezier curves.
+> A [`puppeteer-extra`](https://github.com/berstend/puppeteer-extra) / [`playwright-extra`](https://github.com/berstend/puppeteer-extra/tree/master/packages/playwright-extra) plugin for human-like mouse and keyboard interactions.
 
-On **Puppeteer** it wraps [`ghost-cursor`](https://github.com/Xetera/ghost-cursor).
+On **Puppeteer** it wraps [`ghost-cursor`](https://github.com/Xetera/ghost-cursor) for mouse movement.
 On **Playwright** it uses a built-in Bezier curve implementation via `page.mouse`.
+The platform is auto-detected per page at runtime — no configuration needed.
 
 ## Install
 
@@ -17,64 +18,85 @@ npm install puppeteer-extra-plugin-ghost-cursor
 
 ## Usage
 
-### Puppeteer
-
 ```js
+// Puppeteer
 const puppeteer = require('puppeteer-extra')
 const GhostCursorPlugin = require('puppeteer-extra-plugin-ghost-cursor')
 
 puppeteer.use(GhostCursorPlugin())
 
-const browser = await puppeteer.launch({ headless: false })
-const page = await browser.newPage()
+const page = await (await puppeteer.launch({ headless: false })).newPage()
 await page.goto('https://example.com')
 
-await page.humanClick('button#submit')       // curved move + click
-await page.humanMove(500, 300)               // curved move, no click
+await page.humanClick('button#submit')           // curved move + click
+await page.humanType('input#search', 'hello')    // click field + human typing
+await page.humanMove(500, 300)                   // curved move, no click
 await page.ghostCursor.moveTo({ x: 200, y: 400 }) // raw cursor access
 ```
 
-### Playwright
-
 ```js
+// Playwright — identical API, no ghost-cursor dep needed
 const { chromium } = require('playwright-extra')
 const GhostCursorPlugin = require('puppeteer-extra-plugin-ghost-cursor')
 
 chromium.use(GhostCursorPlugin())
 
-const browser = await chromium.launch({ headless: false })
-const page = await browser.newPage()
-await page.goto('https://example.com')
-
-await page.humanClick('button#submit')       // Bezier path + click
-await page.humanMove(500, 300)               // Bezier path, no click
+const page = await (await chromium.launch()).newPage()
+await page.humanClick('button#submit')
+await page.humanType('input#email', 'user@example.com', { wpm: 120 })
 // page.ghostCursor is null on Playwright
 ```
 
-## Autonomous debug mode
+## Features
 
-Enable `debug: true` to get automatic failure recovery and diagnostics:
+### Cursor position memory
+
+The last known cursor position is stored per page. Every `humanMove` and
+`humanClick` call starts from the correct location rather than `(0, 0)`,
+producing coherent paths across multiple interactions.
+
+### Automatic scroll-to-element
+
+If `boundingBox()` returns `null` because the target is off-screen, the plugin
+calls `scrollIntoView({ block: 'center' })` and retries automatically before
+raising an error.
+
+### Variable click position
+
+Clicks land at a random point within the central 60% of the element bounding
+box. Humans do not click the exact pixel centre every time.
+
+### Ease-in/ease-out speed curve
+
+Mouse steps are timed with a sine curve so the cursor accelerates at the
+start of a move and decelerates near the target, matching natural hand motion.
+Total travel time has ±20% random variance.
+
+### Human-like typing (`humanType`)
+
+Keystroke delays vary per character. Pauses are longer after punctuation and
+spaces, and a 7% random "hesitation" pause is inserted to simulate thinking.
+Speed is configurable via `opts.wpm` (default: 180 wpm).
+
+### Autonomous debug mode
+
+Enable `debug: true` to get automatic failure recovery:
 
 ```js
-puppeteer.use(GhostCursorPlugin({
-  debug: true,
-  debugDir: 'my-debug-screenshots'  // default: 'ghost-cursor-debug'
-}))
+puppeteer.use(GhostCursorPlugin({ debug: true, debugDir: 'my-debug' }))
 ```
 
-When `humanClick` fails, the plugin automatically:
+When `humanClick` fails the plugin:
 
-1. Takes a full-page JPEG screenshot and saves it to `debugDir`.
-2. Logs the target selector, current page URL and error message.
-3. Retries **once** using a direct `page.click()` fallback (no cursor movement).
-4. Reports whether the fallback succeeded.
-
-If the fallback also fails, the original error is re-thrown — nothing is silently swallowed.
+1. Saves a full-page JPEG screenshot to `debugDir`.
+2. Logs the selector, page URL and error.
+3. Retries once with a direct `page.click()` / `locator.click()` fallback.
+4. Re-throws the original error only if the fallback also fails.
 
 ```
 [ghost-cursor] humanClick failed on "button#submit" @ https://example.com
   Error   : Element has no boundingBox — hidden or detached
-  Snapshot: ghost-cursor-debug/2025-01-15T10-30-00-000Z_button_submit.jpg
+  Snapshot: my-debug/2025-01-15T10-30-00Z_button_submit.jpg
 [ghost-cursor] Fallback click succeeded for "button#submit".
 ```
 
@@ -82,21 +104,30 @@ If the fallback also fails, the original error is re-thrown — nothing is silen
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `moveDelay` | `number` | `0` | Ms to wait between move completion and click |
-| `debug` | `boolean` | `false` | Enable autonomous debug mode |
-| `debugDir` | `string` | `'ghost-cursor-debug'` | Directory for debug screenshots |
+| `moveDelay` | `number` | `0` | Extra ms between move end and click |
+| `debug` | `boolean` | `false` | Autonomous debug mode |
+| `debugDir` | `string` | `'ghost-cursor-debug'` | Screenshot output directory |
 
 ## API
 
 ### `page.humanClick(selectorOrHandle)`
 
-Moves to the centre of the target element via a Bezier-curved path, then fires a native mouse click. Accepts a CSS selector string or an `ElementHandle` (Puppeteer) / `Locator` (Playwright).
+Moves to the target element via a Bezier-curved path with ease-in/ease-out
+timing, then fires a native mouse click at a random point within the central
+60% of the element. Scrolls the element into view if needed.
 
-Coordinates are resolved via `boundingBox()` rather than ghost-cursor's built-in `click(handle)` to avoid silent misses on elements that are partially off-screen or inside scrollable containers.
+Accepts a CSS selector string, `ElementHandle` (Puppeteer), or `Locator`
+(Playwright).
 
 ### `page.humanMove(x, y)`
 
-Moves the cursor to the given viewport coordinates via a Bezier-curved path, without clicking.
+Moves to the given coordinates via a Bezier path. Updates cursor position
+memory so the next move starts from here.
+
+### `page.humanType(selector, text [, opts])`
+
+Clicks the target field, then types each character with randomised inter-key
+delays. `opts.wpm` controls approximate speed (default: `180`).
 
 ### `page.ghostCursor`
 


### PR DESCRIPTION
## Summary

Adds `puppeteer-extra-plugin-ghost-cursor` — human-like mouse and keyboard interactions for both Puppeteer and Playwright, with autonomous debug recovery.

---

## Platform support

| Platform | Mouse engine | Extra dep needed |
|----------|-------------|-----------------|
| Puppeteer | `ghost-cursor` (peer dep) | `npm i ghost-cursor` |
| Playwright | Built-in Bezier via `page.mouse` | none |

Auto-detected per page at runtime via `typeof page.locator === 'function'`.

---

## Helpers added to every page

### `page.humanClick(selectorOrHandle)`

Moves to the target element via a Bezier-curved path, then fires a native mouse click. Accepts CSS selector, `ElementHandle` (Puppeteer) or `Locator` (Playwright).

### `page.humanMove(x, y)`

Curved move to coordinates, no click.

### `page.humanType(selector, text [, { wpm }])`

Clicks the target field, then types each character with randomised inter-key delays. Pauses are longer after punctuation and spaces; a 7% random hesitation pause simulates thinking. Speed is configurable via `wpm` (default 180).

### `page.ghostCursor`

Raw `GhostCursor` instance for advanced use (Puppeteer only, `null` on Playwright).

---

## Behaviour details

### 1 — Cursor position memory

The last cursor position is stored per page. Every move starts from the correct location instead of `(0, 0)`, producing coherent paths across multiple interactions.

### 2 — Automatic scroll-to-element

If `boundingBox()` returns `null` (element off-screen), the plugin calls `scrollIntoView({ block: 'center' })` and retries before raising an error.

### 3 — Variable click position

Clicks land at a random point within the central 60% of the bounding box. Humans do not click the exact pixel centre every time.

### 4 — Ease-in/ease-out speed curve

Move steps are timed with a sine curve so the cursor accelerates at the start and decelerates near the target. Total travel time has ±20% random variance.

### 5 — Autonomous debug mode (`opts.debug: true`)

When `humanClick` fails:
1. Full-page JPEG screenshot saved to `opts.debugDir`.
2. Selector, page URL and error logged to console.
3. Retry once with direct `page.click()` / `locator.click()` fallback.
4. Re-throws original error only if fallback also fails — nothing silently swallowed.

---

## Checklist

- [x] Works with `puppeteer-extra` and `playwright-extra`
- [x] Platform auto-detected at runtime
- [x] `ghost-cursor` is a `peerDependency` — only needed for Puppeteer path
- [x] Playwright path has zero extra dependencies
- [x] All five behaviour features implemented and documented
- [x] CommonJS + JSDoc style consistent with existing plugins
- [x] `debug: false` by default — opt-in only
